### PR TITLE
fix: add logging for lastNotified checks in sendTransferEvent

### DIFF
--- a/src/common/utils/events.ts
+++ b/src/common/utils/events.ts
@@ -38,10 +38,12 @@ export async function sendTransferEvent(
     // If lastNotified is null, it means we're processing historical blocks and should skip
     if (lastNotified === undefined) {
       lastNotified = await getLastNotified(store)
+      console.log('LastNotified timestamp for NFT', nft.id, lastNotified)
     }
     
     // If lastNotified is null (explicitly passed for historical blocks), skip sending event
     if (lastNotified === null) {
+      console.log('Not sending transfer event for NFT', nft.id, 'because lastNotified is null')
       return
     }
 


### PR DESCRIPTION
- Added console logs to track the lastNotified timestamp and the decision to skip sending transfer events when lastNotified is null. This improves debugging and visibility into event handling during NFT transfers.