### PR TITLE
fix: derive isCreditSale from address files instead of hardcoded list

### DIFF
--- a/src/polygon/modules/analytics.ts
+++ b/src/polygon/modules/analytics.ts
@@ -28,16 +28,11 @@ import {
   updateUniqueAndMythicItemsSet,
   updateUniqueCollectorsSet,
 } from "./accountsDayData";
-
-const CREDIT_CONTRACTS = [
-  "0xa1691afad71b9a92d329f1a95c39d3077d8f2f5f", // old CreditsManager contract Amoy
-  "0x037566bc90f85e76587e1b07f9184585f09c1420", // new CreditsManager contract Amoy
-  "0x6a03991dfa9d661ef7ad3c6f88b31f16e5a282cf", // CreditsManager contract Mainnet
-  "0xe9f961e6ded4e1476bbee4faab886d63a2493eb9", // new CreditsManager contract Mainnet
-];
+import { Network as DclNetwork } from "@dcl/schemas";
+import { getAddresses } from "../../common/utils/addresses";
 
 function isCreditSale(buyer: string): boolean {
-  return CREDIT_CONTRACTS.includes(buyer);
+  return (getAddresses(DclNetwork.MATIC).CreditsManager as string[]).includes(buyer);
 }
 
 export function isTransakOperation(buyer: string): boolean {


### PR DESCRIPTION
## Problem

  `analytics.ts` had a hardcoded `CREDIT_CONTRACTS` array used by `isCreditSale()` to detect purchases made through a CreditsManager contract. This list had diverged from the actual deployed contracts. Specifically, `0x8b3a40ca1b6f5cafc99d112a4d02e897d1fd8cc5` (the latest mainnet CreditsManager) was already present in `addresses/mainnet.ts` and subscribed to in `processor.ts`, but missing from `CREDIT_CONTRACTS`.

  ### Impact

  `trackSale()` resolves the real buyer like this:

      sale.buyer =
        isThirdPartySale(buyer) || isCreditSale(buyer)
          ? await getOwner(...)  // real user ✅
          : buyer;               // CreditsManager contract address ❌

  When `isCreditSale()` returns false for an unrecognized CreditsManager address, `sale.buyer` is set to the CreditsManager contract address instead of the actual NFT recipient. Downstream: events-notifier emits ITEM_SOLD with metadata.buyer = CreditsManager, and badges (Emotionista, Fashionista) track progress against the contract — never awarding the badge to the real user.

  ## Fix

  Remove the hardcoded `CREDIT_CONTRACTS` array and read directly from `getAddresses(Network.MATIC).CreditsManager` — the same source already used by `processor.ts`. Adding a new CreditsManager deployment now only requires updating `addresses/mainnet.ts` or `addresses/amoy.ts`; everything else picks it up automatically.

  ## Notes
This fix only affects future indexing. Past sales stored with the wrong buyer address require a subgraph re-index from the block where `0x8b3a40ca1b6f5cafc99d112a4d02e897d1fd8cc5` was first used to retroactively correct affected records.