### PR TITLE
chore: upgrade evm-processor and add gateway api key

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@graphile/pg-aggregates": "^0.1.1",
         "@subsquid/evm-abi": "^0.3.1",
         "@subsquid/evm-codec": "^0.3.0",
-        "@subsquid/evm-processor": "^1.21.2",
+        "@subsquid/evm-processor": "^1.30.1",
         "@subsquid/file-store": "^2.0.0",
         "@subsquid/graphql-server": "^4.9.0",
         "@subsquid/openreader": "^5.2.0",
@@ -1614,35 +1614,100 @@
       }
     },
     "node_modules/@subsquid/evm-processor": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.26.1.tgz",
-      "integrity": "sha512-nDnwnxNdkgwbj2iHRHJSLlJFMRD+D7Ewo/q2W0m9kL9hYSRErBwGZRyucxivbSDpzQmdaESP8vm/IJ3h21Hncg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.30.1.tgz",
+      "integrity": "sha512-7wOZaaw2lBVfSnhiDBDwUTf93jv7G6A6AdmqV4OWs9GWXLcQAdmL8PgcCFTKguMFvxgXsSx5y+uWs7llWDecLA==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/http-client": "^1.5.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/rpc-client": "^4.11.0",
-        "@subsquid/util-internal": "^3.2.0",
-        "@subsquid/util-internal-archive-client": "^0.1.2",
-        "@subsquid/util-internal-hex": "^1.2.2",
-        "@subsquid/util-internal-ingest-tools": "^1.1.4",
-        "@subsquid/util-internal-processor-tools": "^4.1.1",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/rpc-client": "^4.15.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-archive-client": "^0.2.1",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-ingest-tools": "^1.1.5",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
         "@subsquid/util-internal-range": "^0.3.0",
-        "@subsquid/util-internal-validation": "^0.7.0",
+        "@subsquid/util-internal-validation": "^0.9.0",
         "@subsquid/util-timeout": "^2.3.2"
       }
     },
-    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-processor-tools": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.1.1.tgz",
-      "integrity": "sha512-zzisejusRteAvwjqFDLlFapH9b86E8GdfNswuNWSjASE+VWadJ/PLfrlXFnsbAo4SxPKtqXWEewoK8cjzVjaZA==",
+    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
+      }
+    },
+    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-archive-client": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.2.1.tgz",
+      "integrity": "sha512-jGO3revw8fPSnbEDOZ1ciyZ6sbk9oPbieC8O0n9LipF5Bpc7BBIN6SyTfG9r3bXL86AzN4iMtCKuLtUbkvaFlw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/util-internal-range": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@subsquid/http-client": "^1.8.0",
+        "@subsquid/logger": "^1.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/logger": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-ingest-tools": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.2.0.tgz",
+      "integrity": "sha512-Uufe/pvJ0fBm6UAQetuxGtvZqc1CcwlOtNRiDgZTXiYfyjT2BeykLLiuTQaQ5Pv8iVLRxqfJngge7A63eGvhnQ==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-range": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@subsquid/util-internal-archive-client": "^0.2.1"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/util-internal-archive-client": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-processor-tools": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+      "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/logger": "^1.5.0",
         "@subsquid/util-internal": "^3.2.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-prometheus-server": "^1.3.0",
         "@subsquid/util-internal-range": "^0.3.0",
         "@subsquid/util-internal-squid-id": "^0.0.0",
         "prom-client": "^14.2.0"
+      }
+    },
+    "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-validation": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+      "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+      "license": "GPL-3.0-or-later",
+      "peerDependencies": {
+        "@subsquid/logger": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/logger": {
+          "optional": true
+        }
       }
     },
     "node_modules/@subsquid/evm-typegen": {
@@ -1742,13 +1807,25 @@
       }
     },
     "node_modules/@subsquid/http-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.5.0.tgz",
-      "integrity": "sha512-C7lb67mu/Xhno3x4EOzIPZ9fqixq797rT7DxvKVRXJBE7dYFEPyrOBiKO1W45YwX3lFfuHGKpMu2YBOeS/L7lQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.8.1.tgz",
+      "integrity": "sha512-JDOqZ2DxhOfmZaoeo0+l3MOseTbbhVAz+3VkNBAhfOdenHTKHTYrywjC1AbqtzFZCswW7ErSFsEsIk+y5GsbGQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/@subsquid/http-client/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
       }
     },
     "node_modules/@subsquid/logger": {
@@ -1799,17 +1876,29 @@
       }
     },
     "node_modules/@subsquid/rpc-client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.11.0.tgz",
-      "integrity": "sha512-0vVCqNEsi7OW/9sAEAQL6ljxQ2qmowtfMBVOBefw/l4AAib9e/PR1aS7EuBaiKq56e/iKzMOJigqvnEiS3EwFQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.15.0.tgz",
+      "integrity": "sha512-RwE0TNvX6fyUKk5DB4xXKlZgTLeENkYEHWeCIJH4GJylO4Os2GXYaytzr3NeZc8of7E49qz/HMFSxQvw//Hxyw==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/http-client": "^1.5.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-json-fix-unsafe-integers": "^0.0.0",
         "websocket": "^1.0.34"
+      }
+    },
+    "node_modules/@subsquid/rpc-client/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
       }
     },
     "node_modules/@subsquid/typeorm-codegen": {
@@ -1883,27 +1972,10 @@
       }
     },
     "node_modules/@subsquid/util-internal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.2.0.tgz",
-      "integrity": "sha512-foNCjOmZaP8MKMa9sNe2GXTjFSDM9UqA0I0C0/ZvCxM1lCmG3mxZb70f8Wyi7TePXC/eV8eARbIqFyz0GjQmzA=="
-    },
-    "node_modules/@subsquid/util-internal-archive-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.1.2.tgz",
-      "integrity": "sha512-XATZWOIHUqIuqzb9hxaFIsz/BItb5qLoYjk6uhFcR9ART2AExXLU5l26SvSrq3hUnqfznIkQMZVQ1SKqnGzx4g==",
-      "dependencies": {
-        "@subsquid/util-internal": "^3.1.0",
-        "@subsquid/util-internal-range": "^0.3.0"
-      },
-      "peerDependencies": {
-        "@subsquid/http-client": "^1.4.0",
-        "@subsquid/logger": "^1.3.3"
-      },
-      "peerDependenciesMeta": {
-        "@subsquid/logger": {
-          "optional": true
-        }
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.0.tgz",
+      "integrity": "sha512-WmMPHnqJcVIjM7BRNSd5uGYHVqlakr4fbyUIM2vQmfVx8V2ks+EWoreV0vsnSIyvDEqnoGJl8945xVhYkGkE3A==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
@@ -1929,9 +2001,10 @@
       "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
     },
     "node_modules/@subsquid/util-internal-hex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.2.tgz",
-      "integrity": "sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-http-server": {
       "version": "2.0.0",
@@ -1940,24 +2013,6 @@
       "dependencies": {
         "@subsquid/logger": "^1.3.3",
         "stoppable": "^1.1.0"
-      }
-    },
-    "node_modules/@subsquid/util-internal-ingest-tools": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.1.4.tgz",
-      "integrity": "sha512-2xWyqfg0mITsNdsYuGi3++UTy/D04N69KovyW5Rd71zCDSEedV0ePX5hQl/IT/o+H/u++HcXPggwJMVl09g6kQ==",
-      "dependencies": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
-        "@subsquid/util-internal-range": "^0.3.0"
-      },
-      "peerDependencies": {
-        "@subsquid/util-internal-archive-client": "^0.1.2"
-      },
-      "peerDependenciesMeta": {
-        "@subsquid/util-internal-archive-client": {
-          "optional": true
-        }
       }
     },
     "node_modules/@subsquid/util-internal-json": {
@@ -1971,7 +2026,8 @@
     "node_modules/@subsquid/util-internal-json-fix-unsafe-integers": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-json-fix-unsafe-integers/-/util-internal-json-fix-unsafe-integers-0.0.0.tgz",
-      "integrity": "sha512-mtbN15IgXtV4yo98RQla+O3DhFwB28o3JTBrFuBc/i/qzxyZNbKoVdq/uczomGdXrHxGkWhTDe/istIQe9gn6w=="
+      "integrity": "sha512-mtbN15IgXtV4yo98RQla+O3DhFwB28o3JTBrFuBc/i/qzxyZNbKoVdq/uczomGdXrHxGkWhTDe/istIQe9gn6w==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-processor-tools": {
       "version": "2.0.0",
@@ -2018,6 +2074,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-range/-/util-internal-range-0.3.0.tgz",
       "integrity": "sha512-5/oDNW0TS66o4vWRzYSYXEfNnFRZsAzoi4pZNdPn7n1l+xV7ZTa0Y57XA6cP5hrWCaIYav4z1zECPngLDV/qeQ==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@subsquid/util-internal": "^3.1.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0"
@@ -2026,25 +2083,13 @@
     "node_modules/@subsquid/util-internal-squid-id": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-squid-id/-/util-internal-squid-id-0.0.0.tgz",
-      "integrity": "sha512-LyVZIGUbC87r+3VFBRiNOEycxvpkOEEjt5enY02iGl6MneLwq3m17D44xAkwfFj/U+t7GA76eeHIoI2ZkiQKog=="
+      "integrity": "sha512-LyVZIGUbC87r+3VFBRiNOEycxvpkOEEjt5enY02iGl6MneLwq3m17D44xAkwfFj/U+t7GA76eeHIoI2ZkiQKog==",
+      "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-ts-node": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ts-node/-/util-internal-ts-node-0.0.0.tgz",
       "integrity": "sha512-VBnrKrkNcqbT3hMLrjpEPuwMAihFhW9oUmK53bccBCCXrUiATNUblQD2S4IWd9/UBO5Q33ohpbE9sAodDq2DXw=="
-    },
-    "node_modules/@subsquid/util-internal-validation": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.7.0.tgz",
-      "integrity": "sha512-Y8o7am+btlHxJuPtS/0+qNe+QkyAOuxSSXhccRwj2mRUlYG81MnxWFgYs4ac+pWeayLfU/3SBvQJH5g7L82fTQ==",
-      "peerDependencies": {
-        "@subsquid/logger": "^1.3.3"
-      },
-      "peerDependenciesMeta": {
-        "@subsquid/logger": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@subsquid/util-naming": {
       "version": "1.3.0",
@@ -3421,6 +3466,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -3644,6 +3690,7 @@
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -3658,6 +3705,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -3668,6 +3716,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -3701,6 +3750,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -3783,6 +3833,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -3851,6 +3902,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -4579,7 +4631,8 @@
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "license": "MIT"
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -4941,7 +4994,8 @@
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "license": "ISC"
     },
     "node_modules/node-abort-controller": {
       "version": "3.1.1",
@@ -6009,7 +6063,8 @@
     "node_modules/type": {
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ=="
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "license": "ISC"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -6027,6 +6082,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -6297,6 +6353,7 @@
       "version": "1.0.35",
       "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.35.tgz",
       "integrity": "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",
         "debug": "^2.2.0",
@@ -6313,6 +6370,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -6320,7 +6378,8 @@
     "node_modules/websocket/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "3.0.0",
@@ -6577,6 +6636,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
       "integrity": "sha512-MvQa//+KcZCUkBTIC9blM+CU9J2GzuTytsOUwf2lidtvkx/6gnEp1QvJv34t9vdjhFmha/mUiNDbN0D0mJWdug==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.32"
       }
@@ -7888,29 +7949,58 @@
       }
     },
     "@subsquid/evm-processor": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.26.1.tgz",
-      "integrity": "sha512-nDnwnxNdkgwbj2iHRHJSLlJFMRD+D7Ewo/q2W0m9kL9hYSRErBwGZRyucxivbSDpzQmdaESP8vm/IJ3h21Hncg==",
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-processor/-/evm-processor-1.30.1.tgz",
+      "integrity": "sha512-7wOZaaw2lBVfSnhiDBDwUTf93jv7G6A6AdmqV4OWs9GWXLcQAdmL8PgcCFTKguMFvxgXsSx5y+uWs7llWDecLA==",
       "requires": {
-        "@subsquid/http-client": "^1.5.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/rpc-client": "^4.11.0",
-        "@subsquid/util-internal": "^3.2.0",
-        "@subsquid/util-internal-archive-client": "^0.1.2",
-        "@subsquid/util-internal-hex": "^1.2.2",
-        "@subsquid/util-internal-ingest-tools": "^1.1.4",
-        "@subsquid/util-internal-processor-tools": "^4.1.1",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/rpc-client": "^4.15.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-archive-client": "^0.2.1",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-ingest-tools": "^1.1.5",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
         "@subsquid/util-internal-range": "^0.3.0",
-        "@subsquid/util-internal-validation": "^0.7.0",
+        "@subsquid/util-internal-validation": "^0.9.0",
         "@subsquid/util-timeout": "^2.3.2"
       },
       "dependencies": {
-        "@subsquid/util-internal-processor-tools": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.1.1.tgz",
-          "integrity": "sha512-zzisejusRteAvwjqFDLlFapH9b86E8GdfNswuNWSjASE+VWadJ/PLfrlXFnsbAo4SxPKtqXWEewoK8cjzVjaZA==",
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
           "requires": {
-            "@subsquid/logger": "^1.3.3",
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        },
+        "@subsquid/util-internal-archive-client": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.2.1.tgz",
+          "integrity": "sha512-jGO3revw8fPSnbEDOZ1ciyZ6sbk9oPbieC8O0n9LipF5Bpc7BBIN6SyTfG9r3bXL86AzN4iMtCKuLtUbkvaFlw==",
+          "requires": {
+            "@subsquid/util-internal": "^3.2.0",
+            "@subsquid/util-internal-range": "^0.3.0"
+          }
+        },
+        "@subsquid/util-internal-ingest-tools": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.2.0.tgz",
+          "integrity": "sha512-Uufe/pvJ0fBm6UAQetuxGtvZqc1CcwlOtNRiDgZTXiYfyjT2BeykLLiuTQaQ5Pv8iVLRxqfJngge7A63eGvhnQ==",
+          "requires": {
+            "@subsquid/logger": "^1.6.0",
+            "@subsquid/util-internal": "^3.3.0",
+            "@subsquid/util-internal-range": "^0.3.0"
+          }
+        },
+        "@subsquid/util-internal-processor-tools": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+          "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+          "requires": {
+            "@subsquid/logger": "^1.5.0",
             "@subsquid/util-internal": "^3.2.0",
             "@subsquid/util-internal-counters": "^1.3.2",
             "@subsquid/util-internal-prometheus-server": "^1.3.0",
@@ -7918,6 +8008,12 @@
             "@subsquid/util-internal-squid-id": "^0.0.0",
             "prom-client": "^14.2.0"
           }
+        },
+        "@subsquid/util-internal-validation": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+          "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+          "requires": {}
         }
       }
     },
@@ -7991,13 +8087,25 @@
       }
     },
     "@subsquid/http-client": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.5.0.tgz",
-      "integrity": "sha512-C7lb67mu/Xhno3x4EOzIPZ9fqixq797rT7DxvKVRXJBE7dYFEPyrOBiKO1W45YwX3lFfuHGKpMu2YBOeS/L7lQ==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/http-client/-/http-client-1.8.1.tgz",
+      "integrity": "sha512-JDOqZ2DxhOfmZaoeo0+l3MOseTbbhVAz+3VkNBAhfOdenHTKHTYrywjC1AbqtzFZCswW7ErSFsEsIk+y5GsbGQ==",
       "requires": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "node-fetch": "^3.3.2"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        }
       }
     },
     "@subsquid/logger": {
@@ -8037,17 +8145,29 @@
       }
     },
     "@subsquid/rpc-client": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.11.0.tgz",
-      "integrity": "sha512-0vVCqNEsi7OW/9sAEAQL6ljxQ2qmowtfMBVOBefw/l4AAib9e/PR1aS7EuBaiKq56e/iKzMOJigqvnEiS3EwFQ==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.15.0.tgz",
+      "integrity": "sha512-RwE0TNvX6fyUKk5DB4xXKlZgTLeENkYEHWeCIJH4GJylO4Os2GXYaytzr3NeZc8of7E49qz/HMFSxQvw//Hxyw==",
       "requires": {
-        "@subsquid/http-client": "^1.5.0",
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
         "@subsquid/util-internal-binary-heap": "^1.0.0",
         "@subsquid/util-internal-counters": "^1.3.2",
         "@subsquid/util-internal-json-fix-unsafe-integers": "^0.0.0",
         "websocket": "^1.0.34"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        }
       }
     },
     "@subsquid/typeorm-codegen": {
@@ -8096,18 +8216,9 @@
       }
     },
     "@subsquid/util-internal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.2.0.tgz",
-      "integrity": "sha512-foNCjOmZaP8MKMa9sNe2GXTjFSDM9UqA0I0C0/ZvCxM1lCmG3mxZb70f8Wyi7TePXC/eV8eARbIqFyz0GjQmzA=="
-    },
-    "@subsquid/util-internal-archive-client": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-archive-client/-/util-internal-archive-client-0.1.2.tgz",
-      "integrity": "sha512-XATZWOIHUqIuqzb9hxaFIsz/BItb5qLoYjk6uhFcR9ART2AExXLU5l26SvSrq3hUnqfznIkQMZVQ1SKqnGzx4g==",
-      "requires": {
-        "@subsquid/util-internal": "^3.1.0",
-        "@subsquid/util-internal-range": "^0.3.0"
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.0.tgz",
+      "integrity": "sha512-WmMPHnqJcVIjM7BRNSd5uGYHVqlakr4fbyUIM2vQmfVx8V2ks+EWoreV0vsnSIyvDEqnoGJl8945xVhYkGkE3A=="
     },
     "@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
@@ -8131,9 +8242,9 @@
       "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
     },
     "@subsquid/util-internal-hex": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.2.tgz",
-      "integrity": "sha512-E43HVqf23jP5hvtWF9GsiN8luANjnJ1daR2SVTwaIUAYU/uNjv1Bi6tHz2uexlflBhyxAgBDmHgunXZ45wQTIw=="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-hex/-/util-internal-hex-1.2.3.tgz",
+      "integrity": "sha512-rGIQKHP+RpriJR56oL/AD43H/KX1EQwsvUy8nP6IHnk/vmaLyC2ECTp5n0jB7kq4NYK4C2VotP3lXHR0vWpa0A=="
     },
     "@subsquid/util-internal-http-server": {
       "version": "2.0.0",
@@ -8142,16 +8253,6 @@
       "requires": {
         "@subsquid/logger": "^1.3.3",
         "stoppable": "^1.1.0"
-      }
-    },
-    "@subsquid/util-internal-ingest-tools": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ingest-tools/-/util-internal-ingest-tools-1.1.4.tgz",
-      "integrity": "sha512-2xWyqfg0mITsNdsYuGi3++UTy/D04N69KovyW5Rd71zCDSEedV0ePX5hQl/IT/o+H/u++HcXPggwJMVl09g6kQ==",
-      "requires": {
-        "@subsquid/logger": "^1.3.3",
-        "@subsquid/util-internal": "^3.2.0",
-        "@subsquid/util-internal-range": "^0.3.0"
       }
     },
     "@subsquid/util-internal-json": {
@@ -8225,12 +8326,6 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-ts-node/-/util-internal-ts-node-0.0.0.tgz",
       "integrity": "sha512-VBnrKrkNcqbT3hMLrjpEPuwMAihFhW9oUmK53bccBCCXrUiATNUblQD2S4IWd9/UBO5Q33ohpbE9sAodDq2DXw=="
-    },
-    "@subsquid/util-internal-validation": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.7.0.tgz",
-      "integrity": "sha512-Y8o7am+btlHxJuPtS/0+qNe+QkyAOuxSSXhccRwj2mRUlYG81MnxWFgYs4ac+pWeayLfU/3SBvQJH5g7L82fTQ==",
-      "requires": {}
     },
     "@subsquid/util-naming": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@graphile/pg-aggregates": "^0.1.1",
     "@subsquid/evm-abi": "^0.3.1",
     "@subsquid/evm-codec": "^0.3.0",
-    "@subsquid/evm-processor": "^1.21.2",
+    "@subsquid/evm-processor": "^1.30.1",
     "@subsquid/file-store": "^2.0.0",
     "@subsquid/graphql-server": "^4.9.0",
     "@subsquid/openreader": "^5.2.0",

--- a/src/eth/processor.ts
+++ b/src/eth/processor.ts
@@ -33,7 +33,7 @@ const FINALITY_CONFIRMATION = parseInt(
   process.env.FINALITY_CONFIRMATION_ETH || "75"
 );
 export const processor = new EvmBatchProcessor()
-  .setGateway(GATEWAY)
+  .setGateway({ url: GATEWAY, apiKey: process.env.SQUID_API_KEY })
   .setPrometheusPort(parseInt(process.env.ETH_PROMETHEUS_PORT || "3000"))
   .setRpcEndpoint({
     url: assertNotNull(RPC_ENDPOINT),

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -41,7 +41,7 @@ const FINALITY_CONFIRMATION = parseInt(
 const collections = loadCollections();
 
 export const processor = new EvmBatchProcessor()
-  .setGateway(GATEWAY)
+  .setGateway({ url: GATEWAY, apiKey: process.env.SQUID_API_KEY })
   .setPrometheusPort(parseInt(process.env.POLYGON_PROMETHEUS_PORT || "3001"))
   .setRpcEndpoint({
     url: assertNotNull(RPC_ENDPOINT),

--- a/src/polygon/tools/collectionsRetriever.ts
+++ b/src/polygon/tools/collectionsRetriever.ts
@@ -30,7 +30,7 @@ const GATEWAY = `https://v2.archive.subsquid.io/network/polygon-${
 }`;
 
 const processor = new EvmBatchProcessor()
-  .setGateway(GATEWAY)
+  .setGateway({ url: GATEWAY, apiKey: process.env.SQUID_API_KEY })
   .setRpcEndpoint({
     url: assertNotNull(process.env.RPC_ENDPOINT_POLYGON),
     rateLimit: 10,


### PR DESCRIPTION
## Changes

- Bump \`@subsquid/evm-processor\` from \`^1.21.2\` to \`^1.30.1\`. As of \`1.30.0\` (released 2026-05-05) the Subsquid gateway requires an API key (anonymous access returns 403 \`CREDENTIALS_INVALID\`).
- Pass the API key through \`setGateway({ url, apiKey })\` in:
  - \`src/eth/processor.ts\`
  - \`src/polygon/processor.ts\`
  - \`src/polygon/tools/collectionsRetriever.ts\` (so the retriever tool keeps working too)

The key comes from \`process.env.SQUID_API_KEY\` — same env var name as the other 2 squids for consistency. The matching SSM parameter is being added in the \`definitions\` repo so the secret reaches the container at runtime.

## Test plan

- [ ] CI green
- [ ] Local processor run picks up the key and indexes without 403s on both ETH and Polygon networks