### PR TITLE
fix: only emit gift notifications for genuine transfers, not sales

### DIFF
--- a/src/common/utils/events.ts
+++ b/src/common/utils/events.ts
@@ -1,9 +1,23 @@
 import { Store } from '@subsquid/typeorm-store'
 import { TransferReceivedEvent, Events } from '@dcl/schemas'
-import { TransferEventArgs } from '../../polygon/abi/CollectionV2'
 import { EntityManager } from 'typeorm'
-import { NFT } from '../../model'
 import eventPublisher from './event_publisher'
+
+// A pending TRANSFER_RECEIVED ("gift") notification collected while processing a
+// batch. Whether a transfer is an actual gift (vs a marketplace purchase) can
+// only be decided once the whole batch is processed, because within a single
+// transaction the ERC721 Transfer log is handled before the marketplace event
+// (OrderSuccessful / BidAccepted / Traded) that records the sale. See the
+// post-batch reconciliation in the polygon processor.
+export type TransferGiftCandidate = {
+  nftId: string
+  from: string
+  to: string
+  tokenURI: string | null
+  // NFT.updatedAt, in seconds (matches the block timestamp of the transfer).
+  timestamp: bigint
+  txHash: string
+}
 
 export async function getLastNotified(store: Store): Promise<bigint | null> {
   const em = (store as unknown as { em: () => EntityManager }).em()
@@ -26,50 +40,19 @@ export async function setLastNotified(store: Store, timestamp: bigint) {
   )
 }
 
-export async function sendTransferEvent(
-  store: Store, 
-  nft: NFT, 
-  transferEvent: TransferEventArgs,
-  lastNotified: bigint | null | undefined = undefined
-) {
-  try {
-    // If lastNotified is undefined (not provided), fetch it from the database
-    // This should only happen when processing new blocks (not historical)
-    // If lastNotified is null, it means we're processing historical blocks and should skip
-    if (lastNotified === undefined) {
-      lastNotified = await getLastNotified(store)
-      console.log('LastNotified timestamp for NFT', nft.id, lastNotified)
-    }
-    
-    // If lastNotified is null (explicitly passed for historical blocks), skip sending event
-    if (lastNotified === null) {
-      console.log('Not sending transfer event for NFT', nft.id, 'because lastNotified is null')
-      return
-    }
-
-    // Only send if there's no lastNotified timestamp or if the NFT was updated after the last notification
-    if (lastNotified && nft.updatedAt <= lastNotified) {
-      console.log('Not sending transfer event for NFT', nft.id, 'because it was not updated since the last notified timestamp')
-      return
-    }
-
-    const event: TransferReceivedEvent = {
-      type: Events.Type.BLOCKCHAIN,
-      subType: Events.SubType.Blockchain.TRANSFER_RECEIVED,
-      key: nft.id,
-      timestamp: Number(nft.updatedAt.toString()),
-      metadata: {
-        senderAddress: transferEvent.from,
-        receiverAddress: transferEvent.to,
-        tokenUri: nft.tokenURI ?? undefined,
-      }
-    }
-    await eventPublisher.publishMessage(event)
-    
-    // Update lastNotified timestamp after successfully sending the event
-    await setLastNotified(store, nft.updatedAt)
-  } catch (e) {
-    console.log('Error in sendTransferEvent:', e)
-    console.log('Could not send transfer event for NFT', nft.id)
+// Publishes a single gift notification. The timestamp is emitted in milliseconds
+// to stay consistent with the rest of the notification pipeline.
+export async function publishTransferGift(candidate: TransferGiftCandidate): Promise<void> {
+  const event: TransferReceivedEvent = {
+    type: Events.Type.BLOCKCHAIN,
+    subType: Events.SubType.Blockchain.TRANSFER_RECEIVED,
+    key: candidate.nftId,
+    timestamp: Number(candidate.timestamp) * 1000,
+    metadata: {
+      senderAddress: candidate.from,
+      receiverAddress: candidate.to,
+      tokenUri: candidate.tokenURI ?? undefined,
+    },
   }
+  await eventPublisher.publishMessage(event)
 }

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -963,11 +963,12 @@ export async function handleTransfer(
   event: CollectionV2ABI.TransferEventArgs,
   block: Block,
   storedData: PolygonStoredData,
-  lastNotified: bigint | null = null
+  inMemoryData: PolygonInMemoryState,
+  txHash: string
 ): Promise<void> {
   // Do not compute mints
   if (!isMint(event.from)) {
-    await handleTransferNFT(ctx, collectionAddress, event, block, storedData, lastNotified);
+    await handleTransferNFT(ctx, collectionAddress, event, block, storedData, inMemoryData, txHash);
   } else {
     // console.log(`transfer found but not mint, it was from: ${event.from}`);
   }

--- a/src/polygon/handlers/nft.ts
+++ b/src/polygon/handlers/nft.ts
@@ -29,7 +29,6 @@ import { PolygonInMemoryState, PolygonStoredData } from "../types";
 import { Transaction } from "@subsquid/evm-processor";
 import { trackSale } from "../modules/analytics";
 import { StoreContractData } from "../state";
-import { sendTransferEvent } from "../../common/utils/events";
 
 /**
  * @notice mint an NFT by a collection v2 issue event
@@ -188,7 +187,8 @@ export async function handleTransferNFT(
   event: TransferEventArgs,
   block: Block,
   storedData: PolygonStoredData,
-  lastNotified: bigint | null = null
+  inMemoryData: PolygonInMemoryState,
+  txHash: string
 ): Promise<void> {
   const { nfts, orders } = storedData;
   if (event.tokenId.toString() === "") {
@@ -216,9 +216,19 @@ export async function handleTransferNFT(
   nft.updatedAt = timestamp;
   nft.transferredAt = timestamp;
 
-  if (!nft.activeOrder) {
-    await sendTransferEvent(ctx.store, nft, event, lastNotified);
-  }
+  // Record this transfer as a candidate gift notification. We do NOT emit here:
+  // whether it is an actual gift (vs a marketplace purchase) is decided
+  // post-batch, once every Sale of the batch has been tracked. Within a single
+  // transaction the ERC721 Transfer log is processed before the marketplace
+  // event that records the sale, so the sale is not yet known at this point.
+  inMemoryData.transferGiftCandidates.set(`${txHash}-${nft.id}`, {
+    nftId: nft.id,
+    from: event.from,
+    to: event.to,
+    tokenURI: nft.tokenURI ?? null,
+    timestamp,
+    txHash,
+  });
 
   if (nft.activeOrder) {
     const order = orders.get(nft.activeOrder.id);

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -78,7 +78,11 @@ import {
   getTradeEventData,
   getTradeEventType,
 } from "../common/utils/marketplaceV3";
-import { getLastNotified } from "../common/utils/events";
+import {
+  getLastNotified,
+  setLastNotified,
+  publishTransferGift,
+} from "../common/utils/events";
 
 const schemaName = process.env.DB_SCHEMA;
 const addresses = getAddresses(Network.MATIC);
@@ -88,6 +92,15 @@ const preloadedCollectionsHeight = loadCollections().height;
 // Cache lastNotified timestamp to avoid querying DB for historical blocks
 let cachedLastNotified: bigint | null = null;
 let lastNotifiedLoaded = false;
+// Hard lower bound (epoch seconds) for gift notifications. Unlike last_notified
+// (which lives in public.squids and could be stale), this floor comes from the
+// environment, so it survives any DB wipe / re-index and guarantees we never
+// backfill historical gift notifications. Defaults to process start time when
+// unset, which is also safe (a re-index/restart never replays old gifts).
+const minTransferNotificationTimestamp = BigInt(
+  process.env.MIN_TRANSFER_NOTIFICATION_TIMESTAMP ??
+    Math.floor(Date.now() / 1000)
+);
 
 processor.run(
   new TypeormDatabase({
@@ -156,6 +169,7 @@ processor.run(
       curations,
       mints,
       squidRouterOrders,
+      transferGiftCandidates,
       // ids
       itemIds,
       collectionIds,
@@ -1020,7 +1034,8 @@ processor.run(
               event as CollectionV2ABI.TransferEventArgs,
               block.header,
               storedData,
-              batchLastNotified
+              inMemoryData,
+              log.transactionHash
             );
           } catch (e) {
             console.log('Error in handleTransfer:', e);
@@ -1156,6 +1171,61 @@ processor.run(
     await ctx.store.insert([...transfers.values()]);
     await ctx.store.insert([...curations.values()]);
     await ctx.store.insert([...squidRouterOrders.values()]);
+
+    // --- Gift notifications (TRANSFER_RECEIVED) ---
+    // A transfer is a genuine gift only if it is NOT part of a marketplace
+    // operation. Sales (orders, bids and offchain trades) all create a Sale via
+    // trackSale in this same batch, keyed by (txHash, nft). Any transfer whose
+    // (txHash, nftId) matches a Sale is a purchase and must not notify the buyer
+    // as a gift. We decide this here, post-batch, because within a transaction
+    // the ERC721 Transfer log is processed before the marketplace event that
+    // records the sale.
+    if (transferGiftCandidates.size > 0) {
+      const soldKeys = new Set<string>();
+      for (const sale of sales.values()) {
+        soldKeys.add(`${sale.txHash.toLowerCase()}-${sale.nft.id}`);
+      }
+
+      // Never (re-)emit at or below this floor. The env-based floor protects
+      // against backfilling on a re-index even if last_notified is stale; the
+      // watermark dedupes incrementally at head.
+      const floor =
+        batchLastNotified && batchLastNotified > minTransferNotificationTimestamp
+          ? batchLastNotified
+          : minTransferNotificationTimestamp;
+
+      let maxNotified = floor;
+      let emitted = 0;
+      for (const candidate of transferGiftCandidates.values()) {
+        if (candidate.timestamp <= floor) {
+          continue;
+        }
+        if (
+          soldKeys.has(`${candidate.txHash.toLowerCase()}-${candidate.nftId}`)
+        ) {
+          // It's a marketplace purchase, not a gift.
+          continue;
+        }
+        try {
+          await publishTransferGift(candidate);
+          emitted++;
+          if (candidate.timestamp > maxNotified) {
+            maxNotified = candidate.timestamp;
+          }
+        } catch (e) {
+          console.log(
+            "Error publishing transfer gift for NFT",
+            candidate.nftId,
+            e
+          );
+        }
+      }
+
+      if (emitted > 0 && maxNotified > (batchLastNotified ?? 0n)) {
+        await setLastNotified(ctx.store, maxNotified);
+      }
+    }
+
     // console.log('accounts polygon: ', accounts);
     ctx.log.info(
       `Batch from block: ${ctx.blocks[0].header.height} to ${

--- a/src/polygon/state.ts
+++ b/src/polygon/state.ts
@@ -14,6 +14,7 @@ export const getBatchInMemoryState: () => PolygonInMemoryState = () => ({
   curations: new Map(),
   mints: new Map(),
   transfers: new Map(),
+  transferGiftCandidates: new Map(),
   sales: new Map<string, Sale>(),
   squidRouterOrders: new Map(),
   // ids

--- a/src/polygon/types.ts
+++ b/src/polygon/types.ts
@@ -33,12 +33,17 @@ import {
   MarketplaceV2ContractData,
   StoreContractData,
 } from "./state";
+import { TransferGiftCandidate } from "../common/utils/events";
 
 export type PolygonInMemoryState = {
   sales: Map<string, Sale>;
   curations: Map<string, Curation>;
   mints: Map<string, Mint>;
   transfers: Map<string, Transfer>;
+  // Pending gift notifications collected during the batch, keyed by
+  // `${txHash}-${nftId}`. Reconciled against `sales` post-batch so that
+  // transfers that are actually marketplace purchases are not notified as gifts.
+  transferGiftCandidates: Map<string, TransferGiftCandidate>;
   squidRouterOrders: Map<string, SquidRouterOrder>;
   // ids
   collectionIds: Set<string>;


### PR DESCRIPTION
## Context

A marketplace purchase is also an on-chain ERC721 transfer, so the buyer was receiving a false "X sent you something" gift notification (`TRANSFER_RECEIVED`). The previous emitter only guarded with `!nft.activeOrder`, which does not cover bids or offchain trades (the modern marketplace), so purchases leaked through as gifts.

## Changes

- Stop emitting the gift inline in `handleTransferNFT`. Transfers are collected per batch in `inMemoryData.transferGiftCandidates`, keyed by `txHash-nftId`.
- Post-batch, emit `TRANSFER_RECEIVED` only when there is **no** `Sale` for the same `(txHash, nftId)` in the batch. `trackSale` records orders, bids and offchain trades (`handleTraded`), so purchases are correctly excluded. This is decided post-batch because, within a tx, the ERC721 `Transfer` log is processed before the marketplace event that records the sale.
- Anti-flood: emit only when `timestamp > max(last_notified, MIN_TRANSFER_NOTIFICATION_TIMESTAMP)`. The floor defaults to process start time and can be pinned via the `MIN_TRANSFER_NOTIFICATION_TIMESTAMP` env var; it lives outside the per-deploy schema so it survives DB re-indexes and never backfills historical gifts. `last_notified` advances only on emit.
- Fix: the gift `timestamp` is now emitted in **milliseconds** (the previous, never-published path emitted seconds), consistent with the rest of the notification pipeline.

## Deploy ordering

Deploy this **before** the `definitions` change that adds `AWS_SNS_ARN` to the marketplace squid indexers. Until that env var is present, publishing is skipped, so deploying this code first is a safe no-op. Then deploy `definitions` to start publishing, and only afterwards remove the legacy `nft-transfer` producer in `events-notifier`.

## Test plan

- [ ] `yarn build`
- [ ] After SNS is enabled: buy a wearable/emote on the marketplace → buyer gets **no** gift notification.
- [ ] Gift an NFT (free transfer) → receiver gets the gift notification.
- [ ] A re-index does not flood old gift notifications.
