### PR TITLE
fix: install awscli with --break-system-packages on node 24 alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,10 @@ RUN echo -e "loglevel=silent\\nupdate-notifier=false" > /squid/.npmrc
 RUN npm i -g @subsquid/cli@latest && mv $(which sqd) /usr/local/bin/sqd
 
 # Install jq and AWS CLI v1
+# --break-system-packages is required since the node:24-alpine base image ships
+# a PEP 668 "externally-managed" Python, which otherwise rejects the pip install.
 RUN apk update && apk add --no-cache tini postgresql-client curl jq python3 py3-pip \
-    && pip3 install awscli \
+    && pip3 install --break-system-packages awscli \
     && rm -rf /var/cache/apk/*
 
 ENV ETH_PROMETHEUS_PORT 3000


### PR DESCRIPTION
## Context

The Docker image build (buildah → quay) started failing after the bump to `node:24-alpine` (#81). The newer Alpine base ships a PEP 668 "externally-managed" Python, so `pip3 install awscli` now aborts with:

```
error: externally-managed-environment
Error: building at STEP "RUN apk update && apk add ... python3 py3-pip && pip3 install awscli ...": exit status 1
```

CI run: https://github.com/decentraland/marketplace-squid-core/actions/runs/27290642392

## Changes

- Add `--break-system-packages` to the `pip3 install awscli` step in the `Dockerfile`. This is the documented PEP 668 escape hatch and keeps the exact same AWS CLI v1 (used by `indexer.sh` for `aws ecs describe-tasks`) — no behavior change beyond unblocking the install.

## Test plan

- [ ] CI image build (buildah) completes past the `pip3 install awscli` step

> Note: couldn't run the Docker build locally (daemon unavailable); relying on CI to validate. A cleaner long-term alternative is dropping pip and using Alpine's `aws-cli` package (`apk add aws-cli`), but `--break-system-packages` is the minimal, lowest-risk fix to unblock the build now.