### PR TITLE
fix: lowercase factory-created collection ids so their events are indexed

### DIFF
--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -265,8 +265,11 @@ processor.run(
                 ? CollectionFactoryABI.events.ProxyCreated.decode(log)
                 : CollectionFactoryV3ABI.events.ProxyCreated.decode(log);
 
-            // collectionsCreatedByFactory.add(event._address.toLowerCase());
-            collectionIdsCreatedInBatch.add(event._address); // add the Id to the list of collections to be processed
+            // Store lowercase: subsquid delivers `log.address` lowercase, so the collection-event
+            // guard below (and collections.get in the handlers) only match a lowercase id. A checksummed
+            // id here silently drops every later Issue/Transfer/SetApproved for the collection — this is
+            // exactly what `collectionIds.add(event._address.toLowerCase())` a few lines down already does.
+            collectionIdsCreatedInBatch.add(event._address.toLowerCase()); // add the Id to the list of collections to be processed
 
             const collectionContract = new CollectionV2ABI.Contract(
               ctx,
@@ -884,7 +887,10 @@ processor.run(
       await handleCollectionCreation(
         ctx,
         block.header,
-        event._address,
+        // Lowercase the id: it's what collections.get(log.address) and the event guard match against
+        // (subsquid log addresses are lowercase). A checksummed id makes the collection unreachable to
+        // all its later events — no NFTs get minted into the index and approval never propagates.
+        event._address.toLowerCase(),
         storedData,
         usedCredits,
         creditValue,


### PR DESCRIPTION
## The bug

Subsquid delivers `log.address` **lowercase**, but a factory-created collection was registered with its **checksummed** address, so it never matched its own later events.

- `main.ts` (ProxyCreated dispatch): `collectionIdsCreatedInBatch.add(event._address)` — not lowercased (the lowercased version was even sitting right there, commented out).
- `main.ts` (create call): `handleCollectionCreation(ctx, block, event._address, …)` — passes the checksummed address, which becomes `Collection.id`.

The per-log collection-event guard only processes a log when `log.address` (lowercase) is in `preloadedCollections` ∪ `collectionIdsNotIncludedInPreloaded` (DB ids) ∪ `collectionIdsCreatedInBatch`. With a checksummed id in the DB/batch sets, the guard `break`s for every `Issue` / `Transfer` / `SetApproved` / `AddItem` of that collection. Even if it didn't, `collections.get(log.address)` inside `handleIssue`/`handleSetApproved`/`handleMintNFT` would miss (checksummed key).

### Observed effect
For any collection **not in the preloaded snapshot**:
- The collection + its initial items are created (via RPC reads at creation), so items appear…
- …but **no NFTs are ever minted into the index** (`Issue` skipped) → bought items never show in the owner's wardrobe / `/v1/nfts`.
- **Approval never propagates** (`SetApproved` skipped) → `isApproved` stays stale even though the collection is approved on-chain.

`collectionIds.add(event._address.toLowerCase())` a few lines down already lowercases the same value — this restores that convention to the two places that dropped it.

### Why prod didn't surface it
It's latent, not Amoy-specific. The preloaded snapshot is what saves you, and it differs sharply by network:
- **mainnet**: `height 65358331`, **5483** collections (fresh + comprehensive) → virtually every real collection is preloaded (lowercase) and works.
- **amoy**: `height 10541238`, **40** collections, ~32M blocks stale (head ~42.2M) → almost every collection created on Amoy falls into the buggy dynamic path.

## The fix

Lowercase the collection address at both spots so ids are consistently lowercase (matching the snapshot, `log.address`, and downstream `${log.address}-…` id building).

## Test plan / rollout

- [x] `tsc --noEmit`
- [ ] **Requires a re-sync** (or reprocessing from each affected collection's creation block) to repair already-indexed collections stored with a checksummed id.
- [ ] After resync: an unapproved→approved collection reflects `isApproved`, and a freshly-minted item appears under `/v1/nfts?owner=…&contractAddress=…`.