### PR TITLE
fix: index usd-pegged (credits) trades so minted items reach the owner

### DIFF
--- a/src/common/utils/marketplaceV3.ts
+++ b/src/common/utils/marketplaceV3.ts
@@ -9,9 +9,18 @@ export enum TradeType {
 
 export enum TradeAssetType {
   ERC20 = 1,
+  USD_PEGGED_MANA = 2,
   ERC721 = 3,
   ITEM = 4,
 }
+
+// Payment asset types that settle in MANA: plain ERC20 MANA and the USD-pegged MANA the credits
+// checkout (the Shop) uses. Both are priced in the MANA contract, so a trade whose payment leg is
+// either one is a MANA sale/bid — see getTradeEventType.
+const MANA_PAYMENT_ASSET_TYPES = [
+  TradeAssetType.ERC20,
+  TradeAssetType.USD_PEGGED_MANA,
+];
 
 export const getTradeEventType = (
   event: TradedEventArgs,
@@ -19,22 +28,27 @@ export const getTradeEventType = (
 ): TradeType | undefined => {
   const addresses = getAddresses(network);
 
-  // We're only supporting the case of one trade for the moment. We could have multiple trades in the future
-  const isReceivingERC20 =
-    Number(event._trade.received[0].assetType) === TradeAssetType.ERC20;
-  const isSendingERC20 =
-    Number(event._trade.sent[0].assetType) === TradeAssetType.ERC20;
+  // We're only supporting the case of one trade for the moment. We could have multiple trades in the future.
+  // A MANA payment leg is either plain ERC20 MANA or USD-pegged MANA (the credits/Shop checkout) — both
+  // must be recognized, otherwise a credits sale is misclassified and its collection/tokenId are read off
+  // the wrong asset, so the mint never gets indexed.
+  const isReceivingMana = MANA_PAYMENT_ASSET_TYPES.includes(
+    Number(event._trade.received[0].assetType)
+  );
+  const isSendingMana = MANA_PAYMENT_ASSET_TYPES.includes(
+    Number(event._trade.sent[0].assetType)
+  );
   const contractAddressReceived = event._trade.received[0].contractAddress;
   const contractAddressSent = event._trade.sent[0].contractAddress;
 
   // if received is MANA, then it's an order. We could also have other ERC20 sent, but for the moment we are only checking for MANA
   if (
-    isReceivingERC20 &&
+    isReceivingMana &&
     [addresses.MANA, addresses.TRANSAK_TOKEN].includes(contractAddressReceived) // support Transak token to track sales in dev
   ) {
     return TradeType.Order;
   } else if (
-    isSendingERC20 &&
+    isSendingMana &&
     [addresses.MANA, addresses.TRANSAK_TOKEN].includes(contractAddressSent)
   ) {
     return TradeType.Bid;


### PR DESCRIPTION
## Root cause (proven on real data)

The Polygon `Traded` classifier only recognised **ERC20** MANA as a payment leg. Credits/Shop checkout settles the payment leg in **USD-pegged MANA** (`TradeAssetType.USD_PEGGED_MANA = 2`), which was **missing from the enum**, so `getTradeEventType` returned `undefined` for every credits sale.

With `undefined`, `getTradeEventData` fell into the bid branch and read the collection/token off the **payment** asset instead of the **item** asset:
- `collectionAddress` → the MANA token address (wrong), `tokenId`/`itemId` → `undefined`.

Downstream (`polygon/main.ts` Traded case): the wrong address is added to `collectionIds` and the handler `break`s on "tokenId not found". The collection is never loaded into the batch's in-memory map, so when the item's `Issue` mint is processed, `handleMintNFT` hits `collections.get(address) → undefined → "ERROR: Collection not found"` and returns **without creating the NFT**.

### Symptom
For collections sold through the Shop (credits): the collection, its items and approval all index fine, but **mints never produce an NFT** → the buyer's item never appears in `/v1/nfts` / My Assets, even though the on-chain mint succeeded and the credit was consumed.

### Why prod hadn't surfaced it
It's payment-type specific, not network specific: normal MANA (ERC20) marketplace sales classify correctly and work. USD-pegged trades are new — the Shop is their first producer — so only credits purchases hit the gap.

## The fix

Add `USD_PEGGED_MANA = 2` to `TradeAssetType` and treat it as a MANA payment leg in `getTradeEventType` (both the order and bid sides). Then a credits sale classifies as an `Order`, `getTradeEventData` reads the item asset, and the collection/itemId resolve correctly.

## Verification

Decoded the real `Traded` log from a Shop credits purchase (Amoy tx `0x0820ab…`) and ran the compiled helpers:

| | before | after |
|---|---|---|
| `getTradeEventType` | `undefined` | `Order` |
| `collectionAddress` | MANA token (wrong) | `0x1ad4…` (the collection) |
| `itemId` | `undefined` | `3` |

- [x] `tsc` (build)
- [ ] **Requires a re-sync** (or reprocessing from the affected mint blocks) to backfill the NFTs that were dropped.