### PR TITLE
feat: migrate to sqd portal data source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # IDE files
 /.idea
 node_modules
+.env.portal-local

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,16 @@
         "@dcl/schemas": "^20.2.1",
         "@graphile/pg-aggregates": "^0.1.1",
         "@slack/bolt": "^4.2.1",
+        "@subsquid/batch-processor": "^1.0.0",
         "@subsquid/evm-abi": "^0.3.1",
         "@subsquid/evm-codec": "^0.3.0",
+        "@subsquid/evm-objects": "^0.0.3",
         "@subsquid/evm-processor": "^1.30.1",
+        "@subsquid/evm-stream": "^0.1.1",
         "@subsquid/file-store": "^2.0.0",
         "@subsquid/graphql-server": "^4.9.0",
         "@subsquid/openreader": "^5.2.0",
+        "@subsquid/rpc-client": "^4.15.0",
         "@subsquid/typeorm-migration": "^1.3.0",
         "@subsquid/typeorm-store": "^1.5.1",
         "dotenv": "^16.4.5",
@@ -2077,6 +2081,47 @@
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
     },
+    "node_modules/@subsquid/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xUBPY5YrMLeImhbQM15qpZYpVWkQVfZwGdMaOL6PAvn/22FL3prITsfDV6UKVmu8qlBITmIuEtllFLDVPs64jA==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-data-source": "^0.0.0",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
+        "@subsquid/util-internal-prometheus-server": "^1.3.0",
+        "@subsquid/util-internal-range": "^0.3.0"
+      }
+    },
+    "node_modules/@subsquid/batch-processor/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
+      }
+    },
+    "node_modules/@subsquid/batch-processor/node_modules/@subsquid/util-internal-processor-tools": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+      "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/logger": "^1.5.0",
+        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-prometheus-server": "^1.3.0",
+        "@subsquid/util-internal-range": "^0.3.0",
+        "@subsquid/util-internal-squid-id": "^0.0.0",
+        "prom-client": "^14.2.0"
+      }
+    },
     "node_modules/@subsquid/big-decimal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/big-decimal/-/big-decimal-1.0.0.tgz",
@@ -2101,6 +2146,18 @@
       "integrity": "sha512-W6EIiC7MJN2oWdbgzpUSDop+UtROdFAlvsrzc10g3AnCAaK31nH59tkTjylRxgECewWFCFWZrwsVp+a+lwvXMA==",
       "dependencies": {
         "@subsquid/util-internal-hex": "^1.2.2"
+      }
+    },
+    "node_modules/@subsquid/evm-objects": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-objects/-/evm-objects-0.0.3.tgz",
+      "integrity": "sha512-rd/x8h31gda3lY4aE4DVrlT8zVxPRxol6CYp99ul4dbmZDTjkFzpUmdGhdfj1VSRDTn3melQ5kxhzh60hYyGGw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal": "^3.3.0"
+      },
+      "peerDependencies": {
+        "@subsquid/evm-stream": "^0.1.0"
       }
     },
     "node_modules/@subsquid/evm-processor": {
@@ -2187,6 +2244,64 @@
       }
     },
     "node_modules/@subsquid/evm-processor/node_modules/@subsquid/util-internal-validation": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+      "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+      "license": "GPL-3.0-or-later",
+      "peerDependencies": {
+        "@subsquid/logger": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/logger": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@subsquid/evm-stream": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-stream/-/evm-stream-0.1.3.tgz",
+      "integrity": "sha512-lABOlhqV1X6vWtj28KVE8B2zkkZtxATnIHigIhLw/+yyDoT6beSKxgufF3kG0E4BqXzc8NKXHE0BIM5/l7Up0g==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/portal-client": "^0.6.0",
+        "@subsquid/util-internal": "^3.3.1",
+        "@subsquid/util-internal-data-source": "^0.0.0",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
+        "@subsquid/util-internal-range": "^0.3.0",
+        "@subsquid/util-internal-validation": "^0.9.0",
+        "@subsquid/util-timeout": "^2.3.2"
+      }
+    },
+    "node_modules/@subsquid/evm-stream/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
+      }
+    },
+    "node_modules/@subsquid/evm-stream/node_modules/@subsquid/util-internal-processor-tools": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+      "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/logger": "^1.5.0",
+        "@subsquid/util-internal": "^3.2.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-prometheus-server": "^1.3.0",
+        "@subsquid/util-internal-range": "^0.3.0",
+        "@subsquid/util-internal-squid-id": "^0.0.0",
+        "prom-client": "^14.2.0"
+      }
+    },
+    "node_modules/@subsquid/evm-stream/node_modules/@subsquid/util-internal-validation": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
       "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
@@ -2365,6 +2480,46 @@
         }
       }
     },
+    "node_modules/@subsquid/portal-client": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/portal-client/-/portal-client-0.6.0.tgz",
+      "integrity": "sha512-lGWmUBzV4iPj6ZtKJeE2P2m2+HqUs/Zqbw41D8sUzYCawsZxJyZN4xkwDMjxOZcR/R1vvs1ABZWNoIhdzzKlrw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal": "^3.3.1",
+        "@subsquid/util-internal-validation": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@subsquid/http-client": "^1.8.1"
+      }
+    },
+    "node_modules/@subsquid/portal-client/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
+      }
+    },
+    "node_modules/@subsquid/portal-client/node_modules/@subsquid/util-internal-validation": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+      "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+      "license": "GPL-3.0-or-later",
+      "peerDependencies": {
+        "@subsquid/logger": "^1.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@subsquid/logger": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@subsquid/rpc-client": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.15.0.tgz",
@@ -2462,9 +2617,9 @@
       }
     },
     "node_modules/@subsquid/util-internal": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.0.tgz",
-      "integrity": "sha512-WmMPHnqJcVIjM7BRNSd5uGYHVqlakr4fbyUIM2vQmfVx8V2ks+EWoreV0vsnSIyvDEqnoGJl8945xVhYkGkE3A==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.1.tgz",
+      "integrity": "sha512-Q8C19KnbI9V3WhEcb5H/r6WHeHiTvBSUBvBZ6W7k7G2G6x5OojtT6CELMb1Yy34PH9DVe0ew7wtd9nM5ZLJ6qg==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@subsquid/util-internal-binary-heap": {
@@ -2489,6 +2644,15 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.2.tgz",
       "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
+    },
+    "node_modules/@subsquid/util-internal-data-source": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-data-source/-/util-internal-data-source-0.0.0.tgz",
+      "integrity": "sha512-3J4FtZy3fl2VQJqYR0ZQU9LsSbpboRsAT49Tf1NDAqYyWbtjDkflMvAkRxq4l1PJR6MQY73nwRDK+0Fv06SizQ==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-range": "^0.3.0"
+      }
     },
     "node_modules/@subsquid/util-internal-hex": {
       "version": "1.2.3",
@@ -9134,6 +9298,46 @@
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.5.tgz",
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw=="
     },
+    "@subsquid/batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha512-xUBPY5YrMLeImhbQM15qpZYpVWkQVfZwGdMaOL6PAvn/22FL3prITsfDV6UKVmu8qlBITmIuEtllFLDVPs64jA==",
+      "requires": {
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/util-internal": "^3.3.0",
+        "@subsquid/util-internal-counters": "^1.3.2",
+        "@subsquid/util-internal-data-source": "^0.0.0",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
+        "@subsquid/util-internal-prometheus-server": "^1.3.0",
+        "@subsquid/util-internal-range": "^0.3.0"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        },
+        "@subsquid/util-internal-processor-tools": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+          "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+          "requires": {
+            "@subsquid/logger": "^1.5.0",
+            "@subsquid/util-internal": "^3.2.0",
+            "@subsquid/util-internal-counters": "^1.3.2",
+            "@subsquid/util-internal-prometheus-server": "^1.3.0",
+            "@subsquid/util-internal-range": "^0.3.0",
+            "@subsquid/util-internal-squid-id": "^0.0.0",
+            "prom-client": "^14.2.0"
+          }
+        }
+      }
+    },
     "@subsquid/big-decimal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@subsquid/big-decimal/-/big-decimal-1.0.0.tgz",
@@ -9158,6 +9362,14 @@
       "integrity": "sha512-W6EIiC7MJN2oWdbgzpUSDop+UtROdFAlvsrzc10g3AnCAaK31nH59tkTjylRxgECewWFCFWZrwsVp+a+lwvXMA==",
       "requires": {
         "@subsquid/util-internal-hex": "^1.2.2"
+      }
+    },
+    "@subsquid/evm-objects": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-objects/-/evm-objects-0.0.3.tgz",
+      "integrity": "sha512-rd/x8h31gda3lY4aE4DVrlT8zVxPRxol6CYp99ul4dbmZDTjkFzpUmdGhdfj1VSRDTn3melQ5kxhzh60hYyGGw==",
+      "requires": {
+        "@subsquid/util-internal": "^3.3.0"
       }
     },
     "@subsquid/evm-processor": {
@@ -9205,6 +9417,55 @@
             "@subsquid/logger": "^1.6.0",
             "@subsquid/util-internal": "^3.3.0",
             "@subsquid/util-internal-range": "^0.3.0"
+          }
+        },
+        "@subsquid/util-internal-processor-tools": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-processor-tools/-/util-internal-processor-tools-4.4.0.tgz",
+          "integrity": "sha512-Ov2gFOcaGr7qVhYoqx+EIUjskGLRJRImQaEal5e0uNjX1sLG1bKfz+rXh1YMYCIUFwKd86fAGyLjVWwvnG0V8w==",
+          "requires": {
+            "@subsquid/logger": "^1.5.0",
+            "@subsquid/util-internal": "^3.2.0",
+            "@subsquid/util-internal-counters": "^1.3.2",
+            "@subsquid/util-internal-prometheus-server": "^1.3.0",
+            "@subsquid/util-internal-range": "^0.3.0",
+            "@subsquid/util-internal-squid-id": "^0.0.0",
+            "prom-client": "^14.2.0"
+          }
+        },
+        "@subsquid/util-internal-validation": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+          "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+          "requires": {}
+        }
+      }
+    },
+    "@subsquid/evm-stream": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@subsquid/evm-stream/-/evm-stream-0.1.3.tgz",
+      "integrity": "sha512-lABOlhqV1X6vWtj28KVE8B2zkkZtxATnIHigIhLw/+yyDoT6beSKxgufF3kG0E4BqXzc8NKXHE0BIM5/l7Up0g==",
+      "requires": {
+        "@subsquid/http-client": "^1.8.1",
+        "@subsquid/logger": "^1.6.0",
+        "@subsquid/portal-client": "^0.6.0",
+        "@subsquid/util-internal": "^3.3.1",
+        "@subsquid/util-internal-data-source": "^0.0.0",
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-processor-tools": "^4.4.0",
+        "@subsquid/util-internal-range": "^0.3.0",
+        "@subsquid/util-internal-validation": "^0.9.0",
+        "@subsquid/util-timeout": "^2.3.2"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
           }
         },
         "@subsquid/util-internal-processor-tools": {
@@ -9356,6 +9617,35 @@
         "ws": "^8.14.2"
       }
     },
+    "@subsquid/portal-client": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/portal-client/-/portal-client-0.6.0.tgz",
+      "integrity": "sha512-lGWmUBzV4iPj6ZtKJeE2P2m2+HqUs/Zqbw41D8sUzYCawsZxJyZN4xkwDMjxOZcR/R1vvs1ABZWNoIhdzzKlrw==",
+      "requires": {
+        "@subsquid/util-internal": "^3.3.1",
+        "@subsquid/util-internal-validation": "^0.9.0"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        },
+        "@subsquid/util-internal-validation": {
+          "version": "0.9.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/util-internal-validation/-/util-internal-validation-0.9.0.tgz",
+          "integrity": "sha512-S9j/o1gmKz4qTf0O8B9mpGV6Z+WhIe6xDLhKvpzJ7IaMqkDUHTu386Hx8IXyTJf/RY9ABunfGLI9q9uJln9wSA==",
+          "requires": {}
+        }
+      }
+    },
     "@subsquid/rpc-client": {
       "version": "4.15.0",
       "resolved": "https://registry.npmjs.org/@subsquid/rpc-client/-/rpc-client-4.15.0.tgz",
@@ -9428,9 +9718,9 @@
       }
     },
     "@subsquid/util-internal": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.0.tgz",
-      "integrity": "sha512-WmMPHnqJcVIjM7BRNSd5uGYHVqlakr4fbyUIM2vQmfVx8V2ks+EWoreV0vsnSIyvDEqnoGJl8945xVhYkGkE3A=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal/-/util-internal-3.3.1.tgz",
+      "integrity": "sha512-Q8C19KnbI9V3WhEcb5H/r6WHeHiTvBSUBvBZ6W7k7G2G6x5OojtT6CELMb1Yy34PH9DVe0ew7wtd9nM5ZLJ6qg=="
     },
     "@subsquid/util-internal-binary-heap": {
       "version": "1.0.0",
@@ -9452,6 +9742,14 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@subsquid/util-internal-counters/-/util-internal-counters-1.3.2.tgz",
       "integrity": "sha512-GxpOIL36JXSo0KdOT7k6CsI4DY804rn/X7pTdfKhych0ReHaDghnwNyvgb7Njv9euEHWUt4MxXbfQ9YrbpPDng=="
+    },
+    "@subsquid/util-internal-data-source": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/util-internal-data-source/-/util-internal-data-source-0.0.0.tgz",
+      "integrity": "sha512-3J4FtZy3fl2VQJqYR0ZQU9LsSbpboRsAT49Tf1NDAqYyWbtjDkflMvAkRxq4l1PJR6MQY73nwRDK+0Fv06SizQ==",
+      "requires": {
+        "@subsquid/util-internal-range": "^0.3.0"
+      }
     },
     "@subsquid/util-internal-hex": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -2,16 +2,23 @@
   "name": "squid-evm-template",
   "private": true,
   "scripts": {
-    "build": "rm -rf lib && tsc"
+    "build": "rm -rf lib && tsc",
+    "db:migrate": "npx squid-typeorm-migration apply",
+    "processor:polygon": "node lib/polygon/main.js",
+    "processor:eth": "node lib/eth/main.js"
   },
   "dependencies": {
     "@aws-sdk/client-sns": "^3.936.0",
     "@dcl/schemas": "^20.2.1",
     "@graphile/pg-aggregates": "^0.1.1",
     "@slack/bolt": "^4.2.1",
+    "@subsquid/batch-processor": "^1.0.0",
     "@subsquid/evm-abi": "^0.3.1",
     "@subsquid/evm-codec": "^0.3.0",
+    "@subsquid/evm-objects": "^0.0.3",
     "@subsquid/evm-processor": "^1.30.1",
+    "@subsquid/evm-stream": "^0.1.1",
+    "@subsquid/rpc-client": "^4.15.0",
     "@subsquid/file-store": "^2.0.0",
     "@subsquid/graphql-server": "^4.9.0",
     "@subsquid/openreader": "^5.2.0",

--- a/src/common/utils/multicall.ts
+++ b/src/common/utils/multicall.ts
@@ -9,6 +9,7 @@ import { getAddresses } from "./addresses";
 const MULTICALL_CONTRACT = "0xcA11bde05977b3631167028862bE2a173976CA11"; // has the same address on different networks
 const hardcodedMulticallCreationBlock = {
   id: "0014353601-7a3f0",
+  number: 14353601,
   height: 14353601,
   hash: "0x7a3f054738fa78c0a9c34a0f4216e40d858a8b086a666860783e9950dbeaf647",
   parentHash:

--- a/src/common/utils/nft.ts
+++ b/src/common/utils/nft.ts
@@ -1,9 +1,7 @@
-import { BlockData } from "@subsquid/evm-processor";
 import {
   Contract as ERC721Contract,
   TransferEventArgs_2,
 } from "../../abi/ERC721";
-import { Block, Context } from "../../eth/processor";
 import {
   Account,
   Category,
@@ -55,9 +53,19 @@ export function getNFTId(
     : contractAddress + "-" + tokenId;
 }
 
+// Minimal structural types for RPC contract reads: only what ContractBase needs.
+// Both the Polygon (evm-processor) and ETH (Portal + rpc-client) contexts satisfy
+// these, so this helper stays shared across processors without coupling to either.
+type RpcContext = {
+  _chain: {
+    client: { call: <T = any>(method: string, params?: unknown[]) => Promise<T> };
+  };
+};
+type RpcBlock = { height: number };
+
 export async function getTokenURI(
-  ctx: Context,
-  block: Block,
+  ctx: RpcContext,
+  block: RpcBlock,
   contractAddress: string,
   tokenId: bigint
 ): Promise<string> {
@@ -67,8 +75,8 @@ export async function getTokenURI(
 }
 
 export async function getOwner(
-  ctx: Context,
-  block: Block,
+  ctx: RpcContext,
+  block: RpcBlock,
   contractAddress: string,
   tokenId: bigint
 ): Promise<string> {

--- a/src/eth/LANDs/utils.ts
+++ b/src/eth/LANDs/utils.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { Contract as LANDRegistryContract } from "../../abi/LANDRegistry";
 import { Estate, NFT, Parcel } from "../../model";
 import { Context } from "../processor";

--- a/src/eth/handlers/bid.ts
+++ b/src/eth/handlers/bid.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { Network } from "@dcl/schemas";
 import { BidCancelledEventArgs } from "../../abi/ERC721Bid";
 import { BidAcceptedEventArgs, BidCreatedEventArgs } from "../../abi/ERC721Bid";

--- a/src/eth/handlers/estate.ts
+++ b/src/eth/handlers/estate.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { Network } from "@dcl/schemas";
 import {
   AddLandEventArgs,

--- a/src/eth/handlers/marketplace.ts
+++ b/src/eth/handlers/marketplace.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { Network } from "@dcl/schemas";
 import {
   OrderCancelledEventArgs,

--- a/src/eth/handlers/nft.ts
+++ b/src/eth/handlers/nft.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import * as CollectionV2ABI from "../../polygon/abi/CollectionV2";
 import * as ERC721Abi from "../../abi/ERC721";
 import { AddWearableEventArgs, TransferEventArgs_2 } from "../../abi/ERC721";

--- a/src/eth/handlers/parcel.ts
+++ b/src/eth/handlers/parcel.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { Network } from "@dcl/schemas";
 import { UpdateEventArgs } from "../../abi/LANDRegistry";
 import { getNFTId } from "../../common/utils/nft";

--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -1,4 +1,6 @@
 import { TypeormDatabase } from "@subsquid/typeorm-store";
+import { run } from "@subsquid/batch-processor";
+import * as evmObjects from "@subsquid/evm-objects";
 import { Network } from "@dcl/schemas";
 import * as landRegistryABI from "../abi/LANDRegistry";
 import * as erc721abi from "../abi/ERC721";
@@ -10,7 +12,7 @@ import * as dclControllerV2abi from "../abi/DCLControllerV2";
 import * as MarketplaceV3ABI from "../abi/DecentralandMarketplaceEthereum";
 import * as SpokeABI from "../abi/Spoke";
 import { Order, Sale, Transfer, Network as ModelNetwork } from "../model";
-import { processor } from "./processor";
+import { dataSource, chainContext, logger, Context } from "./processor";
 import { getNFTId } from "../common/utils";
 import { tokenURIMutilcall } from "../common/utils/multicall";
 import { getAddresses } from "../common/utils/addresses";
@@ -93,13 +95,25 @@ let indicesNeedRecreation = false;
 const ETH_INITIAL_BLOCK = getBlockRange(Network.ETHEREUM).from;
 
 const schemaName = process.env.DB_SCHEMA;
-processor.run(
-  new TypeormDatabase({
-    isolationLevel: "READ COMMITTED",
-    supportHotBlocks: true,
-    stateSchema: `eth_processor_${schemaName}`,
-  }),
-  async (ctx) => {
+const db = new TypeormDatabase({
+  isolationLevel: "READ COMMITTED",
+  // Portal ingests from the finalized stream; a log-filtered stream yields
+  // non-contiguous blocks which the hot-block path rejects. Finality on Ethereum
+  // is ~15 min behind head — acceptable for the marketplace indexer.
+  supportHotBlocks: false,
+  stateSchema: `eth_processor_${schemaName}`,
+});
+run(dataSource, db, async (simpleCtx) => {
+  // The batch-processor base context is bare {store, blocks, isHead}; augment the
+  // blocks (restores block.logs / log.transaction back-refs) and attach `_chain`
+  // (RPC for contract reads) and a logger, so the rest of the handler and the ABI
+  // contract wrappers see the same shape the old evm-processor context provided.
+  const ctx: Context = {
+    ...simpleCtx,
+    ...chainContext,
+    log: logger,
+    blocks: simpleCtx.blocks.map(evmObjects.augmentBlock),
+  };
     // update the amount of bytes read
     bytesRead += ctx.blocks.reduce(
       (acc, block) => acc + Buffer.byteLength(JSON.stringify(block), "utf8"),

--- a/src/eth/processor.ts
+++ b/src/eth/processor.ts
@@ -1,13 +1,9 @@
 import { ChainId, Network } from "@dcl/schemas";
 import { assertNotNull } from "@subsquid/util-internal";
-import {
-  BlockHeader,
-  DataHandlerContext,
-  EvmBatchProcessor,
-  EvmBatchProcessorFields,
-  Log as _Log,
-  Transaction as _Transaction,
-} from "@subsquid/evm-processor";
+import { DataSourceBuilder, FieldSelection } from "@subsquid/evm-stream";
+import * as evmObjects from "@subsquid/evm-objects";
+import { RpcClient } from "@subsquid/rpc-client";
+import { createLogger, Logger } from "@subsquid/logger";
 import { Store } from "@subsquid/typeorm-store";
 import { getAddresses } from "../common/utils/addresses";
 import { getBlockRange } from "../config";
@@ -24,105 +20,154 @@ import * as SpokeABI from "../abi/Spoke";
 const addresses = getAddresses(Network.ETHEREUM);
 const chainId = process.env.ETHEREUM_CHAIN_ID || ChainId.ETHEREUM_MAINNET;
 
-const GATEWAY = `https://v2.archive.subsquid.io/network/ethereum-${
+// SQD Network Portal dataset (replaces the deprecated v2 archive gateway).
+const PORTAL_URL = `https://portal.sqd.dev/datasets/ethereum-${
   chainId == ChainId.ETHEREUM_MAINNET ? "mainnet" : "sepolia"
-}`; // see https://docs.subsquid.io/evm-indexing/supported-networks/
+}`;
 const RPC_ENDPOINT = process.env.RPC_ENDPOINT_ETH;
+const FROM_BLOCK = getBlockRange(Network.ETHEREUM).from;
 
-const FINALITY_CONFIRMATION = parseInt(
-  process.env.FINALITY_CONFIRMATION_ETH || "75"
-);
-export const processor = new EvmBatchProcessor()
-  .setGateway({ url: GATEWAY, apiKey: process.env.SQUID_API_KEY })
-  .setPrometheusPort(parseInt(process.env.ETH_PROMETHEUS_PORT || "3000"))
-  .setRpcEndpoint({
-    url: assertNotNull(RPC_ENDPOINT),
-    rateLimit: 10,
-  })
-  .setFinalityConfirmation(FINALITY_CONFIRMATION)
-  .setFields({
-    log: {
-      transactionHash: true,
+// Field selection for the Portal stream. Portal fetches ONLY these fields — unlike
+// the v2 gateway it does not merge a default set — so anything a handler reads must
+// be listed here (required fields like log topic indices are always present).
+export const fields = {
+  block: { timestamp: true },
+  log: { address: true, topics: true, data: true, transactionHash: true },
+  transaction: { hash: true, from: true, to: true, input: true, value: true },
+} satisfies FieldSelection;
+export type Fields = typeof fields;
+
+// RPC client for contract-state reads (owner(), tokenURI multicall, cuts, ...).
+// Portal only ingests logs/blocks; eth_call still goes through the RPC endpoint,
+// so Portal (data) and RPC (state) run as two independent channels.
+export const rpc = new RpcClient({
+  url: assertNotNull(RPC_ENDPOINT, "RPC_ENDPOINT_ETH is not set"),
+  capacity: 10,
+  rateLimit: 10,
+});
+
+export const logger: Logger = createLogger("sqd:eth");
+
+// A ChainContext for the generated ABI contract wrappers (ContractBase), backed by
+// the RPC client above. Shape matches @subsquid/evm-abi's `Chain` interface.
+export const chainContext = {
+  _chain: {
+    client: {
+      call: <T = any>(method: string, params?: unknown[]): Promise<T> =>
+        rpc.call<T>(method, params as any[]),
+    },
+  },
+};
+
+// Types kept API-compatible with the previous evm-processor exports so handlers and
+// util files do not need to change. `Block` is the block HEADER (matching the prior
+// naming); `Context` is the augmented batch context, including `_chain` for RPC.
+export type Block = evmObjects.BlockHeader<Fields>;
+export type Log = evmObjects.Log<Fields>;
+export type Transaction = evmObjects.Transaction<Fields>;
+export type BlockData = evmObjects.Block<Fields>;
+export interface Context {
+  _chain: typeof chainContext._chain;
+  store: Store;
+  log: Logger;
+  blocks: BlockData[];
+  isHead: boolean;
+}
+
+const erc721TransferTopics = [
+  erc721Abi.events[
+    "Transfer(address indexed,address indexed,uint256 indexed,address,bytes,bytes)"
+  ].topic,
+  erc721Abi.events[
+    "Transfer(address indexed,address indexed,uint256 indexed,address,bytes)"
+  ].topic,
+  erc721Abi.events["Transfer(address indexed,address indexed,uint256 indexed)"]
+    .topic,
+  erc721Abi.events["Transfer(address indexed,address indexed,uint256)"].topic,
+  erc721Abi.events.OwnershipTransferred.topic,
+  erc721Abi.events.AddWearable.topic,
+];
+
+export const dataSource = new DataSourceBuilder()
+  .setPortal(PORTAL_URL)
+  .setBlockRange({ from: FROM_BLOCK })
+  .setFields(fields)
+  .addLog({
+    where: {
+      address: [
+        addresses.LANDRegistry,
+        addresses.EstateRegistry,
+        addresses.DCLRegistrar,
+        ...Object.values(addresses.collections as string[]),
+      ],
+      topic0: erc721TransferTopics,
     },
   })
-  .setBlockRange(getBlockRange(Network.ETHEREUM))
   .addLog({
-    address: [
-      addresses.LANDRegistry,
-      addresses.EstateRegistry,
-      addresses.DCLRegistrar,
-      ...Object.values(addresses.collections as string[]),
-    ],
-    topic0: [
-      erc721Abi.events[
-        "Transfer(address indexed,address indexed,uint256 indexed,address,bytes,bytes)"
-      ].topic,
-      erc721Abi.events[
-        "Transfer(address indexed,address indexed,uint256 indexed,address,bytes)"
-      ].topic,
-      erc721Abi.events[
-        "Transfer(address indexed,address indexed,uint256 indexed)"
-      ].topic,
-      erc721Abi.events["Transfer(address indexed,address indexed,uint256)"]
-        .topic,
-      erc721Abi.events.OwnershipTransferred.topic,
-      erc721Abi.events.AddWearable.topic,
-    ],
+    where: {
+      address: [addresses.LANDRegistry, addresses.EstateRegistry],
+      topic0: [
+        landRegistryAbi.events.Update.topic,
+        estateRegistryAbi.events.CreateEstate.topic,
+        estateRegistryAbi.events.AddLand.topic,
+        estateRegistryAbi.events.RemoveLand.topic,
+        estateRegistryAbi.events.Update.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.LANDRegistry, addresses.EstateRegistry],
-    topic0: [
-      landRegistryAbi.events.Update.topic,
-      estateRegistryAbi.events.CreateEstate.topic,
-      estateRegistryAbi.events.AddLand.topic,
-      estateRegistryAbi.events.RemoveLand.topic,
-      estateRegistryAbi.events.Update.topic,
-    ],
+    where: {
+      address: [addresses.Marketplace],
+      topic0: [
+        marketplaceAbi.events.OrderCreated.topic,
+        marketplaceAbi.events.OrderSuccessful.topic,
+        marketplaceAbi.events.OrderCancelled.topic,
+        marketplaceAbi.events.ChangedOwnerCutPerMillion.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.Marketplace],
-    topic0: [
-      marketplaceAbi.events.OrderCreated.topic,
-      marketplaceAbi.events.OrderSuccessful.topic,
-      marketplaceAbi.events.OrderCancelled.topic,
-      marketplaceAbi.events.ChangedOwnerCutPerMillion.topic,
-    ],
+    where: {
+      address: [addresses.DCLRegistrar],
+      topic0: [dclRegistrarAbi.events.NameRegistered.topic],
+    },
   })
   .addLog({
-    address: [addresses.DCLRegistrar],
-    topic0: [dclRegistrarAbi.events.NameRegistered.topic],
+    where: {
+      address: [addresses.ERC721Bid],
+      topic0: [
+        erc721BidAbi.events.BidAccepted.topic,
+        erc721BidAbi.events.BidCreated.topic,
+        erc721BidAbi.events.BidCancelled.topic,
+        erc721BidAbi.events.ChangedOwnerCutPerMillion.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.ERC721Bid],
-    topic0: [
-      erc721BidAbi.events.BidAccepted.topic,
-      erc721BidAbi.events.BidCreated.topic,
-      erc721BidAbi.events.BidCancelled.topic,
-      erc721BidAbi.events.ChangedOwnerCutPerMillion.topic,
-    ],
+    where: {
+      address: [addresses.DCLControllerV2],
+      topic0: [dclControllerV2.events.NameBought.topic],
+    },
   })
   .addLog({
-    address: [addresses.DCLControllerV2],
-    topic0: [dclControllerV2.events.NameBought.topic],
+    where: {
+      address: [addresses.MarketplaceV3],
+      topic0: [MarketplaceV3.events.Traded.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.MarketplaceV3],
-    topic0: [MarketplaceV3.events.Traded.topic],
+    where: {
+      address: [addresses.MarketplaceV3_V2],
+      topic0: [MarketplaceV3.events.Traded.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.MarketplaceV3_V2],
-    topic0: [MarketplaceV3.events.Traded.topic],
+    where: {
+      address: [addresses.Spoke],
+      topic0: [SpokeABI.events.OrderFilled.topic],
+    },
+    include: { transaction: true },
   })
-  .addLog({
-    transaction: true,
-    address: [addresses.Spoke],
-    topic0: [SpokeABI.events.OrderFilled.topic],
-  });
-
-export type Fields = EvmBatchProcessorFields<typeof processor>;
-export type Context = DataHandlerContext<Store, Fields>;
-export type Block = BlockHeader<Fields>;
-export type Log = _Log<Fields>;
-export type Transaction = _Transaction<Fields>;
+  .build();

--- a/src/eth/state.ts
+++ b/src/eth/state.ts
@@ -6,7 +6,7 @@ import { getAddresses } from "../common/utils/addresses";
 import { Contract as MarketplaceContract } from "../abi/Marketplace";
 import { Contract as ERC721BidContract } from "../abi/ERC721Bid";
 import { Context } from "./processor";
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "./processor";
 import { startBlockByNetwork } from "./data/contracts/start-blocks";
 
 export const getBatchInMemoryState: () => EthereumInMemoryState = () => ({

--- a/src/eth/types.ts
+++ b/src/eth/types.ts
@@ -1,4 +1,4 @@
-import { BlockData, Log } from "@subsquid/evm-processor";
+import { BlockData, Log } from "./processor";
 import * as landRegistryABI from "../abi/LANDRegistry";
 import * as erc721abi from "../abi/ERC721";
 import * as estateRegistryABI from "../abi/EstateRegistry";

--- a/src/polygon/handlers/bid.ts
+++ b/src/polygon/handlers/bid.ts
@@ -1,4 +1,4 @@
-import { BlockData } from "@subsquid/evm-processor";
+import { BlockData } from "../processor";
 import { BidCancelledEventArgs } from "../abi/ERC721Bid";
 import { BidAcceptedEventArgs, BidCreatedEventArgs } from "../../abi/ERC721Bid";
 import { getNFTId } from "../../common/utils";

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -26,7 +26,7 @@ import {
   getBlockWhereRescueItemsStarted,
   getCurationId,
 } from "../modules/curation";
-import { Log, Transaction } from "@subsquid/evm-processor";
+import { Log, Transaction } from "../processor";
 import { handleMintNFT, handleTransferNFT } from "./nft";
 import { isMint } from "../../common/utils";
 import { StoreContractData } from "../state";

--- a/src/polygon/handlers/marketplace.ts
+++ b/src/polygon/handlers/marketplace.ts
@@ -1,4 +1,4 @@
-import { BlockData, Transaction } from "@subsquid/evm-processor";
+import { BlockData, Transaction } from "../processor";
 import { Network } from "@dcl/schemas";
 import {
   OrderCancelledEventArgs,

--- a/src/polygon/handlers/nft.ts
+++ b/src/polygon/handlers/nft.ts
@@ -26,7 +26,7 @@ import { TradedEventArgs } from "../abi/DecentralandMarketplacePolygon";
 import { setNFTSearchFields } from "../modules/metadata";
 import { Block, Context } from "../processor";
 import { PolygonInMemoryState, PolygonStoredData } from "../types";
-import { Transaction } from "@subsquid/evm-processor";
+import { Transaction } from "../processor";
 import { trackSale } from "../modules/analytics";
 import { StoreContractData } from "../state";
 

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -64,7 +64,9 @@ import {
   handleTransferOwnership,
   handleUpdateItemData,
 } from "./handlers/collection";
-import { processor } from "./processor";
+import { dataSource, chainContext, logger, Context } from "./processor";
+import { run } from "@subsquid/batch-processor";
+import * as evmObjects from "@subsquid/evm-objects";
 import {
   getBatchInMemoryState,
   getBidV2ContractData,
@@ -310,13 +312,25 @@ async function performUpserts(
   return { timing, nftsWithOrdersCount: nftsWithOrders.length };
 }
 
-processor.run(
-  new TypeormDatabase({
-    isolationLevel: "READ COMMITTED",
-    supportHotBlocks: true,
-    stateSchema: `polygon_processor_${schemaName}`,
-  }),
-  async (ctx) => {
+const db = new TypeormDatabase({
+  isolationLevel: "READ COMMITTED",
+  // Portal ingests from the finalized stream; a log-filtered stream yields
+  // non-contiguous blocks which the hot-block path rejects. Polygon finality is
+  // only a few blocks (~seconds) behind head, so this stays effectively real-time.
+  supportHotBlocks: false,
+  stateSchema: `polygon_processor_${schemaName}`,
+});
+run(dataSource, db, async (simpleCtx) => {
+  // The batch-processor base context is bare {store, blocks, isHead}; augment the
+  // blocks (restores block.logs / log.transaction back-refs) and attach `_chain`
+  // (RPC for contract reads) and a logger, so the rest of the handler and the ABI
+  // contract wrappers see the same shape the old evm-processor context provided.
+  const ctx: Context = {
+    ...simpleCtx,
+    ...chainContext,
+    log: logger,
+    blocks: simpleCtx.blocks.map(evmObjects.augmentBlock),
+  };
     const batchStartTime = performance.now();
     const metrics = {
       blockRange: `${ctx.blocks[0].header.height}-${

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -1,12 +1,8 @@
 import { assertNotNull } from "@subsquid/util-internal";
-import {
-  BlockHeader,
-  DataHandlerContext,
-  EvmBatchProcessor,
-  EvmBatchProcessorFields,
-  Log as _Log,
-  Transaction as _Transaction,
-} from "@subsquid/evm-processor";
+import { DataSourceBuilder, FieldSelection } from "@subsquid/evm-stream";
+import * as evmObjects from "@subsquid/evm-objects";
+import { RpcClient } from "@subsquid/rpc-client";
+import { createLogger, Logger } from "@subsquid/logger";
 import { Store } from "@subsquid/typeorm-store";
 import { ChainId, Network } from "@dcl/schemas";
 import * as CollectionFactoryABI from "./abi/CollectionFactory";
@@ -29,148 +25,181 @@ import { startBlockByNetwork } from "./addresses/startBlocks";
 
 const addresses = getAddresses(Network.MATIC);
 const chainId = process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET;
-const GATEWAY = `https://v2.archive.subsquid.io/network/polygon-${
+
+// SQD Network Portal dataset (replaces the deprecated v2 archive gateway).
+const PORTAL_URL = `https://portal.sqd.dev/datasets/polygon-${
   chainId == ChainId.MATIC_MAINNET ? "mainnet" : "amoy-testnet"
 }`;
 const RPC_ENDPOINT = process.env.RPC_ENDPOINT_POLYGON;
-
-const FINALITY_CONFIRMATION = parseInt(
-  process.env.FINALITY_CONFIRMATION_POLYGON || "500"
-);
 const collections = loadCollections();
 
-export const processor = new EvmBatchProcessor()
-  .setGateway({ url: GATEWAY, apiKey: process.env.SQUID_API_KEY })
-  .setPrometheusPort(parseInt(process.env.POLYGON_PROMETHEUS_PORT || "3001"))
-  .setRpcEndpoint({
-    url: assertNotNull(RPC_ENDPOINT),
-    rateLimit: 10,
-  })
-  .setFinalityConfirmation(FINALITY_CONFIRMATION)
-  .setFields({
-    transaction: {
-      input: true,
+// Field selection for the Portal stream. Portal fetches ONLY these fields — unlike
+// the v2 gateway it does not merge a default set — so anything a handler reads must
+// be listed here (required fields like log topic indices are always present).
+export const fields = {
+  block: { timestamp: true },
+  log: { address: true, topics: true, data: true, transactionHash: true },
+  transaction: { hash: true, from: true, to: true, input: true, value: true },
+} satisfies FieldSelection;
+export type Fields = typeof fields;
+
+// RPC client for contract-state reads (owner(), the collection multicall, rarities,
+// item/store data). Portal only ingests logs/blocks; eth_call still goes through the
+// RPC endpoint, so Portal (data) and RPC (state) run as two independent channels.
+export const rpc = new RpcClient({
+  url: assertNotNull(RPC_ENDPOINT, "RPC_ENDPOINT_POLYGON is not set"),
+  capacity: 10,
+  rateLimit: 10,
+});
+
+export const logger: Logger = createLogger("sqd:polygon");
+
+// A ChainContext for the generated ABI contract wrappers (ContractBase / Multicall),
+// backed by the RPC client above. Shape matches @subsquid/evm-abi's `Chain`.
+export const chainContext = {
+  _chain: {
+    client: {
+      call: <T = any>(method: string, params?: unknown[]): Promise<T> =>
+        rpc.call<T>(method, params as any[]),
     },
-    log: {
-      transactionHash: true,
-    },
-  })
+  },
+};
+
+// Types kept API-compatible with the previous evm-processor exports so handlers and
+// util files do not need to change. `Block` is the block HEADER (matching the prior
+// naming); `Context` is the augmented batch context, including `_chain` for RPC.
+export type Block = evmObjects.BlockHeader<Fields>;
+export type Log = evmObjects.Log<Fields>;
+export type Transaction = evmObjects.Transaction<Fields>;
+export type BlockData = evmObjects.Block<Fields>;
+export interface Context {
+  _chain: typeof chainContext._chain;
+  store: Store;
+  log: Logger;
+  blocks: BlockData[];
+  isHead: boolean;
+}
+
+const collectionV2Topics = [
+  CollectionV2ABI.events.SetGlobalMinter.topic,
+  CollectionV2ABI.events.SetGlobalManager.topic,
+  CollectionV2ABI.events.SetItemMinter.topic,
+  CollectionV2ABI.events.SetItemManager.topic,
+  CollectionV2ABI.events.AddItem.topic,
+  CollectionV2ABI.events.RescueItem.topic,
+  CollectionV2ABI.events.UpdateItemData.topic,
+  CollectionV2ABI.events.Issue.topic,
+  CollectionV2ABI.events.SetApproved.topic,
+  CollectionV2ABI.events.SetEditable.topic,
+  CollectionV2ABI.events.Complete.topic,
+  CollectionV2ABI.events.CreatorshipTransferred.topic,
+  CollectionV2ABI.events.OwnershipTransferred.topic,
+  CollectionV2ABI.events.Transfer.topic,
+];
+
+export const dataSource = new DataSourceBuilder()
+  .setPortal(PORTAL_URL)
   .setBlockRange(getBlockRange(Network.MATIC))
+  .setFields(fields)
   .addLog({
-    address: [addresses.CollectionFactory, addresses.CollectionFactoryV3],
-    topic0: [
-      CollectionFactoryABI.events.ProxyCreated.topic,
-      CollectionFactoryV3ABI.events.ProxyCreated.topic,
-    ],
+    where: {
+      address: [addresses.CollectionFactory, addresses.CollectionFactoryV3],
+      topic0: [
+        CollectionFactoryABI.events.ProxyCreated.topic,
+        CollectionFactoryV3ABI.events.ProxyCreated.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.Marketplace, addresses.MarketplaceV2],
-    topic0: [
-      MarketplaceABI.events.OrderCreated.topic,
-      MarketplaceABI.events.OrderSuccessful.topic,
-      MarketplaceABI.events.OrderCancelled.topic,
-      MarketplaceV2ABI.events.OrderCreated.topic,
-      MarketplaceV2ABI.events.OrderSuccessful.topic,
-      MarketplaceV2ABI.events.OrderCancelled.topic,
-    ],
+    where: {
+      address: [addresses.Marketplace, addresses.MarketplaceV2],
+      topic0: [
+        MarketplaceABI.events.OrderCreated.topic,
+        MarketplaceABI.events.OrderSuccessful.topic,
+        MarketplaceABI.events.OrderCancelled.topic,
+        MarketplaceV2ABI.events.OrderCreated.topic,
+        MarketplaceV2ABI.events.OrderSuccessful.topic,
+        MarketplaceV2ABI.events.OrderCancelled.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.Bid, addresses.BidV2],
-    topic0: [
-      BidABI.events.BidCreated.topic,
-      BidABI.events.BidAccepted.topic,
-      BidABI.events.BidCancelled.topic,
-    ],
+    where: {
+      address: [addresses.Bid, addresses.BidV2],
+      topic0: [
+        BidABI.events.BidCreated.topic,
+        BidABI.events.BidAccepted.topic,
+        BidABI.events.BidCancelled.topic,
+      ],
+    },
   })
   .addLog({
-    address: [addresses.OldCommittee, addresses.Committee],
-    topic0: [CommitteeABI.events.MemberSet.topic],
+    where: {
+      address: [addresses.OldCommittee, addresses.Committee],
+      topic0: [CommitteeABI.events.MemberSet.topic],
+    },
   })
   .addLog({
-    transaction: true,
-    address: collections.addresses,
-    topic0: [
-      CollectionV2ABI.events.SetGlobalMinter.topic,
-      CollectionV2ABI.events.SetGlobalManager.topic,
-      CollectionV2ABI.events.SetItemMinter.topic,
-      CollectionV2ABI.events.SetItemManager.topic,
-      CollectionV2ABI.events.AddItem.topic,
-      CollectionV2ABI.events.RescueItem.topic,
-      CollectionV2ABI.events.UpdateItemData.topic,
-      CollectionV2ABI.events.Issue.topic,
-      CollectionV2ABI.events.SetApproved.topic,
-      CollectionV2ABI.events.SetEditable.topic,
-      CollectionV2ABI.events.Complete.topic,
-      CollectionV2ABI.events.CreatorshipTransferred.topic,
-      CollectionV2ABI.events.OwnershipTransferred.topic,
-      CollectionV2ABI.events.Transfer.topic,
-    ],
+    where: { address: collections.addresses, topic0: collectionV2Topics },
+    include: { transaction: true },
     range: {
       from: startBlockByNetwork[parseInt(chainId.toString())].Factory,
       to: collections.height,
     },
   })
   .addLog({
-    transaction: true,
-    topic0: [
-      CollectionV2ABI.events.SetGlobalMinter.topic,
-      CollectionV2ABI.events.SetGlobalManager.topic,
-      CollectionV2ABI.events.SetItemMinter.topic,
-      CollectionV2ABI.events.SetItemManager.topic,
-      CollectionV2ABI.events.AddItem.topic,
-      CollectionV2ABI.events.RescueItem.topic,
-      CollectionV2ABI.events.UpdateItemData.topic,
-      CollectionV2ABI.events.Issue.topic,
-      CollectionV2ABI.events.SetApproved.topic,
-      CollectionV2ABI.events.SetEditable.topic,
-      CollectionV2ABI.events.Complete.topic,
-      CollectionV2ABI.events.CreatorshipTransferred.topic,
-      CollectionV2ABI.events.OwnershipTransferred.topic,
-      CollectionV2ABI.events.Transfer.topic,
-    ],
+    where: { topic0: collectionV2Topics },
+    include: { transaction: true },
     range: { from: collections.height + 1 },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.Rarity, addresses.RaritiesWithOracle],
-    topic0: [
-      RaritiesABI.events.AddRarity.topic,
-      RaritiesABI.events.UpdatePrice.topic,
-      RaritiesWithOracleABI.events.AddRarity.topic,
-      RaritiesWithOracleABI.events.UpdatePrice.topic,
-    ],
+    where: {
+      address: [addresses.Rarity, addresses.RaritiesWithOracle],
+      topic0: [
+        RaritiesABI.events.AddRarity.topic,
+        RaritiesABI.events.UpdatePrice.topic,
+        RaritiesWithOracleABI.events.AddRarity.topic,
+        RaritiesWithOracleABI.events.UpdatePrice.topic,
+      ],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.CollectionManager],
-    topic0: [CollectionManagerABI.events.RaritiesSet.topic],
+    where: {
+      address: [addresses.CollectionManager],
+      topic0: [CollectionManagerABI.events.RaritiesSet.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.MarketplaceV3],
-    topic0: [MarketplaceV3.events.Traded.topic],
+    where: {
+      address: [addresses.MarketplaceV3],
+      topic0: [MarketplaceV3.events.Traded.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.MarketplaceV3_V2],
-    topic0: [MarketplaceV3.events.Traded.topic],
+    where: {
+      address: [addresses.MarketplaceV3_V2],
+      topic0: [MarketplaceV3.events.Traded.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: addresses.CreditsManager,
-    topic0: [CreditsManagerABI.events.CreditUsed.topic],
+    where: {
+      address: addresses.CreditsManager,
+      topic0: [CreditsManagerABI.events.CreditUsed.topic],
+    },
+    include: { transaction: true },
   })
   .addLog({
-    transaction: true,
-    address: [addresses.Spoke],
-    topic0: [SpokeABI.events.OrderCreated.topic],
+    where: {
+      address: [addresses.Spoke],
+      topic0: [SpokeABI.events.OrderCreated.topic],
+    },
+    include: { transaction: true },
     range: {
       from: startBlockByNetwork[parseInt(chainId.toString())].Spoke,
     },
-  });
-
-export type Fields = EvmBatchProcessorFields<typeof processor>;
-export type Context = DataHandlerContext<Store, Fields>;
-export type Block = BlockHeader<Fields>;
-export type Log = _Log<Fields>;
-export type Transaction = _Transaction<Fields>;
+  })
+  .build();

--- a/src/polygon/types.ts
+++ b/src/polygon/types.ts
@@ -1,4 +1,4 @@
-import { BlockData, Log, Transaction } from "@subsquid/evm-processor";
+import { BlockData, Log, Transaction } from "./processor";
 import * as CollectionV2 from "./abi/CollectionV2";
 import * as CollectionFactoryV3ABI from "./abi/CollectionFactoryV3";
 import * as erc721abi from "../abi/ERC721";


### PR DESCRIPTION
## What

Migrates both processors (ETH + Polygon) off the **deprecated v2 archive gateway** onto the **SQD Network Portal**, using the stream SDK (`@subsquid/evm-stream` `DataSourceBuilder` + `@subsquid/batch-processor`). Modeled on `credits-squid-core`, which already runs on Portal.

Stacked on top of the bulk-index-mode + multicall PR (base branch); this PR's diff is only the Portal migration.

## How Portal and RPC coexist

Portal ingests **logs/blocks** only. Contract-state reads (`owner()`, the collection multicall, rarities, `tokenURI`, marketplace/store cuts) still go through **RPC** — Portal and RPC are two independent channels:

- Each processor builds its own `RpcClient` (`@subsquid/rpc-client`) pointed at `RPC_ENDPOINT_*`, wrapped as a `_chain.client` shim. The generated ABI contract wrappers (`ContractBase` / `Multicall`) only need that `Chain` shape, so **all contract-read code is unchanged**.
- The `run(dataSource, db, handler)` context is bare `{store, blocks, isHead}`; each batch augments blocks with `augmentBlock` (restores `block.logs` / `log.transaction` back-refs) and attaches `_chain` + a logger, so the handler and contracts see the same shape the old `DataHandlerContext` provided.

## Key changes

- `src/{eth,polygon}/processor.ts`: `EvmBatchProcessor().setGateway(v2 archive)` → `DataSourceBuilder().setPortal("portal.sqd.dev/datasets/<net>").setFields(...).addLog({where, include, range}).build()`. Explicit `setFields` (Portal doesn't merge v2 defaults). Exposes `dataSource`, `rpc`, `chainContext`, `logger`, and API-compatible `Context`/`Block`/`Log`/`Transaction` types.
- `src/{eth,polygon}/main.ts`: `processor.run(...)` → `run(dataSource, db, ...)`; builds the augmented `ctx`.
- `supportHotBlocks: false` — a log-filtered Portal stream yields non-contiguous blocks that the hot-block path rejects, so it reads the finalized stream (finality is seconds behind head on Polygon, ~15 min on Ethereum L1).
- Type imports repointed from `@subsquid/evm-processor` to the local `processor` module; shared `common/utils/nft.ts` decoupled via minimal structural `RpcContext`/`RpcBlock` so both processors share it.
- `@subsquid/evm-processor` stays only for the standalone `collectionsRetriever` tool.

## Local smoke test (Postgres.app, isolated DB)

- **ETH / sepolia**: indexes cleanly via Portal + RPC — `nft`, `parcel`, `estate`, `transfer`, `order`, `sale` all populate (parcels/estates require `tokenURI`/`owner` RPC reads), `head_sync_status` written, no errors.
- **Polygon / amoy**: indexes via Portal + RPC + **collection multicall** — `collection`, `item`, `metadata`, `nft`, `order`, `sale`, `account` all populate. (Hit one pre-existing amoy edge case: `getStoreContractData` crashes when the CollectionStore `fee()` returns `0x` at a historical block — this is unchanged code, not introduced here; worth a defensive follow-up.)

## Test plan

- [ ] Deploy to zone and confirm both processors index (compare row counts / head progress vs the current v2-based squid).
- [ ] Audit `setFields` against a full mainnet run — a missing field surfaces as `undefined` at runtime, not a compile error.
- [ ] Confirm Prometheus metrics needs (this PR does not wire `PrometheusServer` into `run()` yet — add if monitoring depends on it).
