### PR TITLE
fix: portal backfill crashes on bigint blocks and empty contract reads

### DIFF
--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -116,7 +116,16 @@ run(dataSource, db, async (simpleCtx) => {
   };
     // update the amount of bytes read
     bytesRead += ctx.blocks.reduce(
-      (acc, block) => acc + Buffer.byteLength(JSON.stringify(block), "utf8"),
+      (acc, block) =>
+        acc +
+        Buffer.byteLength(
+          // BigInt-safe: Portal blocks can carry bigint fields that JSON.stringify
+          // rejects; this is only a byte-count metric, so serialize them as strings.
+          JSON.stringify(block, (_k, v) =>
+            typeof v === "bigint" ? v.toString() : v
+          ),
+          "utf8"
+        ),
       0
     );
     console.log("bytesRead: ", bytesRead);

--- a/src/eth/processor.ts
+++ b/src/eth/processor.ts
@@ -33,7 +33,7 @@ const FROM_BLOCK = getBlockRange(Network.ETHEREUM).from;
 export const fields = {
   block: { timestamp: true },
   log: { address: true, topics: true, data: true, transactionHash: true },
-  transaction: { hash: true, from: true, to: true, input: true, value: true },
+  transaction: { hash: true, from: true, to: true, input: true },
 } satisfies FieldSelection;
 export type Fields = typeof fields;
 

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -359,7 +359,16 @@ run(dataSource, db, async (simpleCtx) => {
 
     // update the amount of bytes read
     bytesRead += ctx.blocks.reduce(
-      (acc, block) => acc + Buffer.byteLength(JSON.stringify(block), "utf8"),
+      (acc, block) =>
+        acc +
+        Buffer.byteLength(
+          // BigInt-safe: Portal blocks can carry bigint fields that JSON.stringify
+          // rejects; this is only a byte-count metric, so serialize them as strings.
+          JSON.stringify(block, (_k, v) =>
+            typeof v === "bigint" ? v.toString() : v
+          ),
+          "utf8"
+        ),
       0
     );
 

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -39,7 +39,7 @@ const collections = loadCollections();
 export const fields = {
   block: { timestamp: true },
   log: { address: true, topics: true, data: true, transactionHash: true },
-  transaction: { hash: true, from: true, to: true, input: true, value: true },
+  transaction: { hash: true, from: true, to: true, input: true },
 } satisfies FieldSelection;
 export type Fields = typeof fields;
 

--- a/src/polygon/state.ts
+++ b/src/polygon/state.ts
@@ -104,8 +104,15 @@ export const getStoreContractData = async (ctx: Context, block: Block) => {
       block,
       addresses.CollectionStore
     );
-    storeContractData.fee = await storeContract.fee();
-    storeContractData.feeOwner = await storeContract.feeOwner();
+    try {
+      storeContractData.fee = await storeContract.fee();
+      storeContractData.feeOwner = await storeContract.feeOwner();
+    } catch (e: any) {
+      // The contract may not be readable at this (historical) block on some RPC
+      // providers — e.g. fee() returns 0x and decoding throws. Leave the data
+      // undefined and retry on a later batch rather than crashing the processor.
+      console.log(`WARN: could not fetch store contract data: ${e.message}`);
+    }
   }
   return storeContractData;
 };
@@ -131,8 +138,12 @@ export const getMarketplaceContractData = async (
     console.log("INFO: Fetching Marketplace v1 contract data for first time");
     const addresses = getAddresses(Network.MATIC);
     const c = new MarketplaceContract(ctx, block, addresses.Marketplace);
-    marketplaceContractData.ownerCutPerMillion = await c.ownerCutPerMillion();
-    marketplaceContractData.owner = await c.owner();
+    try {
+      marketplaceContractData.ownerCutPerMillion = await c.ownerCutPerMillion();
+      marketplaceContractData.owner = await c.owner();
+    } catch (e: any) {
+      console.log(`WARN: could not fetch marketplace contract data: ${e.message}`);
+    }
   }
   return marketplaceContractData;
 };
@@ -156,11 +167,15 @@ export const getMarketplaceV2ContractData = async (
     console.log("INFO: Fetching marketplace v2 contract data for first time");
     const addresses = getAddresses(Network.MATIC);
     const c = new MarketplaceV2Contract(ctx, block, addresses.MarketplaceV2);
-    marketplaceV2ContractData.feesCollectorCutPerMillion =
-      await c.feesCollectorCutPerMillion();
-    marketplaceV2ContractData.feesCollector = await c.feesCollector();
-    marketplaceV2ContractData.royaltiesCutPerMillion =
-      await c.royaltiesCutPerMillion();
+    try {
+      marketplaceV2ContractData.feesCollectorCutPerMillion =
+        await c.feesCollectorCutPerMillion();
+      marketplaceV2ContractData.feesCollector = await c.feesCollector();
+      marketplaceV2ContractData.royaltiesCutPerMillion =
+        await c.royaltiesCutPerMillion();
+    } catch (e: any) {
+      console.log(`WARN: could not fetch marketplace v2 contract data: ${e.message}`);
+    }
   }
   return marketplaceV2ContractData;
 };
@@ -181,10 +196,15 @@ export const getBidV2ContractData = async (ctx: Context, block: Block) => {
     console.log("INFO: Fetching bid v2 contract data for first time");
     const addresses = getAddresses(Network.MATIC);
     const c = new ERC721BidV2Contract(ctx, block, addresses.BidV2);
-    bidV2ContractData.feesCollectorCutPerMillion =
-      await c.feesCollectorCutPerMillion();
-    bidV2ContractData.feesCollector = await c.feesCollector();
-    bidV2ContractData.royaltiesCutPerMillion = await c.royaltiesCutPerMillion();
+    try {
+      bidV2ContractData.feesCollectorCutPerMillion =
+        await c.feesCollectorCutPerMillion();
+      bidV2ContractData.feesCollector = await c.feesCollector();
+      bidV2ContractData.royaltiesCutPerMillion =
+        await c.royaltiesCutPerMillion();
+    } catch (e: any) {
+      console.log(`WARN: could not fetch bid v2 contract data: ${e.message}`);
+    }
   }
   return bidV2ContractData;
 };


### PR DESCRIPTION
Two fixes for crashes the Portal migration (#90) hit on a fresh zone/amoy sync. #90 is already merged; these were pushed to its branch after the merge, so they never reached `main` — hence this follow-up PR.

## Fixes

### 1. `TypeError: Do not know how to serialize a BigInt` (ETH)
The Portal field selection included a bigint transaction field (`value`), and the `bytesRead` metric does `JSON.stringify(block)`, which throws on any BigInt. The v2 gateway selected no transaction fields, so this never happened before.
- Drop bigint tx fields from `setFields` (only string fields are read by handlers).
- Make the `bytesRead` `JSON.stringify` BigInt-safe via a replacer (defense-in-depth).

### 2. `FunctionResultDecodeError: fee() ... 0x` (Polygon)
`getStoreContractData` (and the other `getXContractData`) `eth_call` at a historical amoy block where the RPC returns `0x`; the ABI decoder throws and the batch-processor `run()` terminates the whole process (it does not swallow per-batch errors the way the old evm-processor retried).
- Wrap all contract-data fetches in `polygon/state.ts` in try/catch: on a read failure, leave the data `undefined` and retry on a later batch instead of crashing.

## Verified

Re-ran the Polygon processor locally against amoy: passes block 5706661 (which previously crashed it), keeps indexing, only a non-fatal `WARN`. Build green.