### PR TITLE
fix: expose prometheus metrics endpoint for portal processors

### DIFF
--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -1,5 +1,5 @@
 import { TypeormDatabase } from "@subsquid/typeorm-store";
-import { run } from "@subsquid/batch-processor";
+import { run, PrometheusServer } from "@subsquid/batch-processor";
 import * as evmObjects from "@subsquid/evm-objects";
 import { Network } from "@dcl/schemas";
 import * as landRegistryABI from "../abi/LANDRegistry";
@@ -103,6 +103,11 @@ const db = new TypeormDatabase({
   supportHotBlocks: false,
   stateSchema: `eth_processor_${schemaName}`,
 });
+// Expose Prometheus metrics (sqd_processor_last_block / chain_height) — the squid
+// management server scrapes /metrics on this port to detect a live processor.
+// setGateway used to start this; with the Portal run() we wire it explicitly.
+const prometheus = new PrometheusServer();
+prometheus.setPort(Number(process.env.ETH_PROMETHEUS_PORT || 3000));
 run(dataSource, db, async (simpleCtx) => {
   // The batch-processor base context is bare {store, blocks, isHead}; augment the
   // blocks (restores block.logs / log.transaction back-refs) and attach `_chain`
@@ -1075,5 +1080,6 @@ run(dataSource, db, async (simpleCtx) => {
     } catch (error) {
       ctx.log.error(`error: ${error}`);
     }
-  }
+  },
+  { prometheus }
 );

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -65,7 +65,7 @@ import {
   handleUpdateItemData,
 } from "./handlers/collection";
 import { dataSource, chainContext, logger, Context } from "./processor";
-import { run } from "@subsquid/batch-processor";
+import { run, PrometheusServer } from "@subsquid/batch-processor";
 import * as evmObjects from "@subsquid/evm-objects";
 import {
   getBatchInMemoryState,
@@ -320,6 +320,11 @@ const db = new TypeormDatabase({
   supportHotBlocks: false,
   stateSchema: `polygon_processor_${schemaName}`,
 });
+// Expose Prometheus metrics (sqd_processor_last_block / chain_height) — the squid
+// management server scrapes /metrics on this port to detect a live processor.
+// setGateway used to start this; with the Portal run() we wire it explicitly.
+const prometheus = new PrometheusServer();
+prometheus.setPort(Number(process.env.POLYGON_PROMETHEUS_PORT || 3001));
 run(dataSource, db, async (simpleCtx) => {
   // The batch-processor base context is bare {store, blocks, isHead}; augment the
   // blocks (restores block.logs / log.transaction back-refs) and attach `_chain`
@@ -1830,5 +1835,6 @@ run(dataSource, db, async (simpleCtx) => {
       `Batch ${metrics.blockRange} saved: nfts=${nfts.size}, items=${items.size}, sales=${sales.size}, mints=${mints.size}, transfers=${transfers.size}`
     );
 
-  }
+  },
+  { prometheus }
 );


### PR DESCRIPTION
After the Portal migration (#90), the squid shows **STOPPED** in the squid-management-ui even though both processors index fine.

## Root cause

The management server (`scrapeMetrics`) fetches `http://<ip>:<port>/metrics` per network and reads `sqd_processor_last_block` / `sqd_processor_chain_height`; the UI marks a squid STOPPED when that metrics object is empty (`SquidsTable.tsx`: `isServiceRunning = Object.keys(squid.metrics).length > 0`). The old `EvmBatchProcessor.setPrometheusPort(...)` started that endpoint. The Portal `run()` does not start it automatically, so `/metrics` was unreachable → empty metrics → STOPPED.

## Fix

Wire `PrometheusServer` into `run(dataSource, db, handler, { prometheus })` for both processors, on the ports the management server expects (ETH 3000, Polygon 3001, overridable via `ETH_PROMETHEUS_PORT` / `POLYGON_PROMETHEUS_PORT`).

## Verified

Ran the ETH processor locally and scraped the endpoint:
```
sqd_processor_chain_height 11326784
sqd_processor_last_block 7111101
```
So the management server will now get non-empty metrics and the UI will show the squid as live.