### PR TITLE
fix: persist every nft when one tx mints the same collection item multiple times

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "build": "rm -rf lib && tsc",
+    "test": "npm run build && node --test \"lib/**/*.test.js\"",
     "db:migrate": "npx squid-typeorm-migration apply",
     "processor:polygon": "node lib/polygon/main.js",
     "processor:eth": "node lib/eth/main.js"

--- a/src/polygon/handlers/marketplace.ts
+++ b/src/polygon/handlers/marketplace.ts
@@ -37,6 +37,7 @@ import {
   TradeType,
 } from "../../common/utils/marketplaceV3";
 import { normalizeTimestamp } from "../../common/utils/utils";
+import { selectIssueLogForTrade } from "../utils/issueLog";
 
 export type MarkteplaceEvents =
   | OrderCreatedEventArgs
@@ -318,16 +319,22 @@ export async function handleTraded(
     // item land in the same block (different txs), every read returns the same
     // final totalSupply, so all simulated Issues collide on the same nftId and
     // the earlier mints get overwritten in storage.
-    // Edge case: if a single tx mints the same itemId twice (batch aggregator),
-    // find() returns the first matching Issue. Not a regression vs. the previous
-    // implementation; would need the current Traded log's logIndex to disambiguate.
-    const issueLog = block.logs.find(
-      (l) =>
-        l.transactionIndex === transaction.transactionIndex &&
-        l.address.toLowerCase() === collectionAddress.toLowerCase() &&
-        l.topics[0] === CollectionV2ABI.events.Issue.topic &&
-        BigInt(l.topics[3]) === BigInt(itemId)
-    );
+    //
+    // A single tx can also mint the same itemId multiple times (e.g. buying
+    // several units at once). That emits one Issue log per unit (differing only
+    // by issuedId/tokenId) and one Traded event per unit. Traded events are
+    // processed in log order, so we consume the matching Issue logs in
+    // ascending logIndex order, skipping any already matched to a previous
+    // Traded event in this batch. A plain find() would return the first Issue
+    // log every time and drop every mint after the first for that item.
+    const issueLog = selectIssueLogForTrade<(typeof block.logs)[number]>(block.logs, {
+      transactionIndex: transaction.transactionIndex,
+      collectionAddress,
+      itemId: BigInt(itemId),
+      issueTopic: CollectionV2ABI.events.Issue.topic,
+      blockHeight: block.header.height,
+      consumedIssueLogs: inMemoryData.consumedIssueLogs,
+    });
     if (!issueLog) {
       console.log(
         `ERROR: Issue log not found for trade tx ${transaction.hash} item ${itemId}`

--- a/src/polygon/state.ts
+++ b/src/polygon/state.ts
@@ -24,6 +24,7 @@ export const getBatchInMemoryState: () => PolygonInMemoryState = () => ({
   analyticsIds: new Set(),
   itemDayDataIds: new Set(),
   bidIds: new Set(),
+  consumedIssueLogs: new Set(),
   itemIds: new Map(),
   // events
   transferEvents: new Map(),

--- a/src/polygon/types.ts
+++ b/src/polygon/types.ts
@@ -53,6 +53,12 @@ export type PolygonInMemoryState = {
   analyticsIds: Set<string>;
   itemDayDataIds: Set<string>;
   bidIds: Set<string>;
+  // Issue logs (keyed by `${blockHeight}-${logIndex}`) already matched to a
+  // MarketplaceV3 Traded event during this batch. Ensures that when a single
+  // transaction mints the same item several times, each Traded event consumes a
+  // distinct Issue log (distinct issuedId/tokenId) instead of all resolving to
+  // the first one.
+  consumedIssueLogs: Set<string>;
   // events
   transferEvents: Map<
     string,

--- a/src/polygon/utils/issueLog.test.ts
+++ b/src/polygon/utils/issueLog.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+import { IssueLogLike, selectIssueLogForTrade } from "./issueLog";
+
+const ISSUE_TOPIC =
+  "0x57e2fe3f7dcd918a54e57b2dc0da8e347386daa9d69c3bbf6c8bce2f7e8398c7";
+const COLLECTION = "0x03b1940d80394614a5ba60abbf73fa749068bdad";
+const OTHER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+// itemId is the indexed 4th topic of the Issue event (padded to 32 bytes).
+const topicForItem = (itemId: number) =>
+  "0x" + itemId.toString(16).padStart(64, "0");
+
+const issueLog = (
+  logIndex: number,
+  itemId: number,
+  overrides: Partial<IssueLogLike> = {}
+): IssueLogLike => ({
+  transactionIndex: 0,
+  address: COLLECTION,
+  topics: [ISSUE_TOPIC, "0x", "0x", topicForItem(itemId)],
+  logIndex,
+  ...overrides,
+});
+
+describe("selectIssueLogForTrade", () => {
+  const baseParams = () => ({
+    transactionIndex: 0,
+    collectionAddress: COLLECTION,
+    issueTopic: ISSUE_TOPIC,
+    blockHeight: 42899045,
+    consumedIssueLogs: new Set<string>(),
+  });
+
+  it("when a tx mints the same item twice it returns a distinct Issue log per call", () => {
+    // Mirrors tx 0xa49ba5...: item 5 issued twice, item 15 once, all via MarketplaceV3.
+    const logs: IssueLogLike[] = [
+      issueLog(3, 5), // item 5, issued #1
+      issueLog(10, 5), // item 5, issued #2
+      issueLog(17, 15), // item 15, issued #1
+    ];
+    const consumed = new Set<string>();
+    const params = { ...baseParams(), consumedIssueLogs: consumed };
+
+    const first = selectIssueLogForTrade(logs, { ...params, itemId: 5n });
+    const second = selectIssueLogForTrade(logs, { ...params, itemId: 5n });
+    const third = selectIssueLogForTrade(logs, { ...params, itemId: 15n });
+
+    assert.ok(first && second && third, "all three mints must resolve a log");
+    assert.strictEqual(first.logIndex, 3, "first item-5 Traded -> issued #1");
+    assert.strictEqual(
+      second.logIndex,
+      10,
+      "second item-5 Traded -> issued #2 (previously dropped)"
+    );
+    assert.strictEqual(third.logIndex, 17, "item-15 Traded -> its own log");
+    assert.notStrictEqual(
+      first.logIndex,
+      second.logIndex,
+      "the two item-5 mints must map to different Issue logs"
+    );
+  });
+
+  it("when there is a single mint it returns that log", () => {
+    const logs = [issueLog(3, 5)];
+    const chosen = selectIssueLogForTrade(logs, {
+      ...baseParams(),
+      itemId: 5n,
+    });
+    assert.strictEqual(chosen?.logIndex, 3);
+  });
+
+  it("when there are no more unconsumed logs it returns undefined", () => {
+    const logs = [issueLog(3, 5)];
+    const params = { ...baseParams(), itemId: 5n };
+    assert.ok(selectIssueLogForTrade(logs, params));
+    assert.strictEqual(
+      selectIssueLogForTrade(logs, params),
+      undefined,
+      "the single Issue log is consumed and not reused"
+    );
+  });
+
+  it("when logs are out of order it consumes them in ascending logIndex order", () => {
+    const logs = [issueLog(10, 5), issueLog(3, 5)];
+    const params = { ...baseParams(), itemId: 5n };
+    const first = selectIssueLogForTrade(logs, params);
+    const second = selectIssueLogForTrade(logs, params);
+    assert.strictEqual(first?.logIndex, 3);
+    assert.strictEqual(second?.logIndex, 10);
+  });
+
+  it("when logs belong to another item, tx or contract they are ignored", () => {
+    const logs: IssueLogLike[] = [
+      issueLog(3, 15), // different item
+      issueLog(4, 5, { transactionIndex: 9 }), // different tx
+      issueLog(5, 5, { address: "0xdeadbeef" }), // different contract
+      issueLog(6, 5, { topics: [OTHER_TOPIC, "0x", "0x", topicForItem(5)] }), // not an Issue
+      issueLog(7, 5), // the only valid match
+    ];
+    const chosen = selectIssueLogForTrade(logs, {
+      ...baseParams(),
+      itemId: 5n,
+    });
+    assert.strictEqual(chosen?.logIndex, 7);
+  });
+});

--- a/src/polygon/utils/issueLog.ts
+++ b/src/polygon/utils/issueLog.ts
@@ -1,0 +1,66 @@
+// Minimal structural shape of a subsquid Log needed to pair Issue logs with
+// Traded events. Kept dependency-free so it can be unit tested in isolation.
+export type IssueLogLike = {
+  transactionIndex: number;
+  address: string;
+  topics: string[];
+  logIndex: number;
+};
+
+/**
+ * Selects the Issue log that corresponds to a given MarketplaceV3 `Traded`
+ * event when minting an item as a primary sale.
+ *
+ * A single transaction can mint the same `itemId` more than once (e.g. buying
+ * several units of the same item at once). Each mint emits its own `Issue` log
+ * that differs only by `issuedId`/`tokenId`, and the marketplace emits one
+ * `Traded` event per unit. Because `Traded` events are processed in log order,
+ * we consume the matching `Issue` logs in ascending `logIndex` order and skip
+ * any already matched to a previous `Traded` event in the same batch. Using
+ * `Array.find` on its own would return the first matching `Issue` log every
+ * time and silently drop every mint after the first for that item.
+ *
+ * The chosen log is recorded in `consumedIssueLogs` (keyed by
+ * `${blockHeight}-${logIndex}`) so the next `Traded` event for the same item
+ * picks the following issuance.
+ */
+export function selectIssueLogForTrade<T extends IssueLogLike>(
+  logs: T[],
+  params: {
+    transactionIndex: number;
+    collectionAddress: string;
+    itemId: bigint;
+    issueTopic: string;
+    blockHeight: number;
+    consumedIssueLogs: Set<string>;
+  }
+): T | undefined {
+  const {
+    transactionIndex,
+    collectionAddress,
+    itemId,
+    issueTopic,
+    blockHeight,
+    consumedIssueLogs,
+  } = params;
+
+  const matchingIssueLogs = logs
+    .filter(
+      (l) =>
+        l.transactionIndex === transactionIndex &&
+        l.address.toLowerCase() === collectionAddress.toLowerCase() &&
+        l.topics[0] === issueTopic &&
+        BigInt(l.topics[3]) === BigInt(itemId)
+    )
+    .sort((a, b) => a.logIndex - b.logIndex);
+
+  const chosen = matchingIssueLogs.find(
+    (l) => !consumedIssueLogs.has(`${blockHeight}-${l.logIndex}`)
+  );
+
+  if (chosen) {
+    consumedIssueLogs.add(`${blockHeight}-${chosen.logIndex}`);
+  }
+
+  return chosen;
+}

--- a/src/polygon/utils/issueLog.ts
+++ b/src/polygon/utils/issueLog.ts
@@ -49,8 +49,9 @@ export function selectIssueLogForTrade<T extends IssueLogLike>(
       (l) =>
         l.transactionIndex === transactionIndex &&
         l.address.toLowerCase() === collectionAddress.toLowerCase() &&
+        l.topics.length >= 4 &&
         l.topics[0] === issueTopic &&
-        BigInt(l.topics[3]) === BigInt(itemId)
+        BigInt(l.topics[3]) === itemId
     )
     .sort((a, b) => a.logIndex - b.logIndex);
 


### PR DESCRIPTION
## Problem

When a single transaction mints multiple NFTs of the **same collection item** (consecutive `issuedId`s) through the MarketplaceV3 primary-sale path, the `nft` table ends up **missing** all but the first unit of that item.

Verified on-chain (Polygon Amoy), tx `0xa49ba5d8e7382b90b6affe2d5df5264fa4b3db9876ccd4ccb68dcc6750041aef` (block `42899045`): it mints item 5 issued #1, item 5 issued #2, and item 15 issued #1 (collection `0x03b1940d80394614a5ba60abbf73fa749068bdad`). The indexer stored only item 5 issued #1 and item 15 issued #1 — **item 5 issued #2 was dropped**.

## Root cause

`handleTraded` (item / primary-sale branch) located the `Issue` log for a `Traded` event with `block.logs.find(...)` keyed by `(transactionIndex, collectionAddress, Issue topic, itemId)` only — never by `issuedId`/`tokenId` or log ordering. The tx emits one `Traded` event and one `Issue` log per minted unit; both item-5 `Traded` events therefore resolved to the **same first** `Issue` log, so `handleMintNFT` re-created the same `tokenId` and never produced the sibling's row. This exact edge case was even called out in a code comment ("`find()` returns the first matching Issue … would need the current Traded log's logIndex to disambiguate") but left unfixed.

Issuance counters were already correct (`handleIssue` decrements `available` / increments `totalSupply` once per `Traded` event) — only the distinct NFT row was lost.

## Fix

`Traded` events are processed in log order, so the matching `Issue` logs are now consumed in ascending `logIndex` order, skipping any already matched to a previous `Traded` event in the same batch (tracked via a new per-batch `consumedIssueLogs` set). This is extracted into a dependency-free helper `selectIssueLogForTrade`, so every distinct `tokenId` minted in one tx is now persisted. Issuance counting is unchanged.

## Tests

Added `src/polygon/utils/issueLog.test.ts` (Node's built-in `node:test`, run via `npm test`) covering the multi-mint-same-item scenario from the tx above plus ordering / filtering / consumption edge cases. All pass.
