### PR TITLE
fix: attribute a sale to its signer, not to whoever was paid

### DIFF
--- a/src/common/utils/marketplaceV3.test.ts
+++ b/src/common/utils/marketplaceV3.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert";
+import { describe, it } from "node:test";
+
+// getAddresses picks the address book from the chain id, so this has to be set before the module under
+// test resolves it.
+process.env.POLYGON_CHAIN_ID = "80002";
+
+import { Network } from "@dcl/schemas";
+
+import { getTradeEventData, TradeAssetType } from "./marketplaceV3";
+import { MANA } from "../../polygon/addresses/amoy";
+
+/**
+ * Who a sale is attributed to.
+ *
+ * The payment leg's `beneficiary` means "who gets paid", and for years that was also "who sold" —
+ * nobody redirected a payment. The Shop does: it signs listings that pay the platform treasury, which
+ * credits the seller off-chain. Reading the seller off that beneficiary silently reassigned every such
+ * sale to the treasury, which is what these tests pin against.
+ */
+
+const SELLER = "0x2a4f9a28ba76413ef182351d864cc2916e462c3b";
+const BUYER = "0x747c6f502272129bf1ba872a1903045b837ee86c";
+const TREASURY = "0x3eedeceafa4797d36819c1d9f8e3b0071285ad69";
+const COLLECTION = "0x03b1940d80394614a5ba60abbf73fa749068bdad";
+
+type Asset = {
+  assetType: number;
+  contractAddress: string;
+  value: bigint;
+  beneficiary: string;
+  extra: string;
+};
+
+const asset = (over: Partial<Asset> = {}): Asset => ({
+  assetType: TradeAssetType.ERC721,
+  contractAddress: COLLECTION,
+  value: 1n,
+  beneficiary: BUYER,
+  extra: "0x",
+  ...over,
+});
+
+const manaAsset = (beneficiary: string, assetType = TradeAssetType.ERC20) =>
+  asset({ assetType, contractAddress: MANA, value: 4079992178284085849n, beneficiary });
+
+/** A Traded event, shaped like the ABI decoder produces it. Only the fields the mapping reads. */
+const tradedEvent = (opts: {
+  signer: string;
+  caller: string;
+  sent: Asset[];
+  received: Asset[];
+}) =>
+  ({
+    _caller: opts.caller,
+    _signature: "0x" + "0".repeat(64),
+    _trade: { signer: opts.signer, sent: opts.sent, received: opts.received },
+  } as never);
+
+describe("getTradeEventData — sale attribution", () => {
+  describe("an order (a listing, signed by its seller)", () => {
+    it("should attribute the sale to the signer, not to whoever was paid", () => {
+      // THE regression: the Shop routes the MANA to the treasury and credits the seller off-chain. The
+      // seller still sold it — reading `received[0].beneficiary` here made their sales disappear from
+      // /v1/sales?seller= and credited the treasury in `updateCreatorsSupportedSet`.
+      const event = tradedEvent({
+        signer: SELLER,
+        caller: BUYER,
+        sent: [asset({ beneficiary: BUYER })],
+        received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.seller, SELLER);
+      assert.strictEqual(data.buyer, BUYER);
+    });
+
+    it("should be unchanged when the seller is paid directly", () => {
+      // Every historical row. Signer and payment beneficiary are the same address, so a reindex under
+      // this change has to reproduce them identically — that is what makes the fix safe to ship.
+      const event = tradedEvent({
+        signer: SELLER,
+        caller: BUYER,
+        sent: [asset({ beneficiary: BUYER })],
+        received: [manaAsset(SELLER)],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.seller, SELLER);
+      assert.strictEqual(data.buyer, BUYER);
+    });
+
+    it("should still read the asset side for the buyer and the price", () => {
+      const event = tradedEvent({
+        signer: SELLER,
+        caller: BUYER,
+        sent: [asset({ beneficiary: BUYER, value: 42n })],
+        received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.collectionAddress, COLLECTION);
+      assert.strictEqual(data.tokenId, 42n);
+      assert.strictEqual(data.price, 4079992178284085849n);
+    });
+  });
+
+  describe("a bid (signed by its buyer, accepted by its seller)", () => {
+    it("should attribute the sale to the caller who accepted, not to whoever was paid", () => {
+      // The same hazard mirrored. No bid redirects its payment today, so this is a guard rather than a
+      // fix — it keeps the invariant true if the Shop ever routes bid proceeds too.
+      const event = tradedEvent({
+        signer: BUYER,
+        caller: SELLER,
+        sent: [manaAsset(TREASURY)],
+        received: [asset({ beneficiary: BUYER })],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.seller, SELLER);
+      assert.strictEqual(data.buyer, BUYER);
+    });
+
+    it("should be unchanged when the seller is paid directly", () => {
+      const event = tradedEvent({
+        signer: BUYER,
+        caller: SELLER,
+        sent: [manaAsset(SELLER)],
+        received: [asset({ beneficiary: BUYER })],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.seller, SELLER);
+      assert.strictEqual(data.buyer, BUYER);
+    });
+  });
+});

--- a/src/common/utils/marketplaceV3.ts
+++ b/src/common/utils/marketplaceV3.ts
@@ -55,6 +55,25 @@ export const getTradeEventType = (
   }
 };
 
+/**
+ * Who sold and who bought, from a Traded event.
+ *
+ * `sent` and `received` are written from the SIGNER's perspective, and a `beneficiary` answers "who
+ * receives this asset". For the ASSET leg that is the same question as "who bought it", so the buyer is
+ * still read from there. For the PAYMENT leg it is not: it answers "who gets paid", which coincided with
+ * "who sold" only for as long as every seller was paid directly.
+ *
+ * They stopped coinciding. The Shop signs listings whose payment beneficiary is the platform treasury,
+ * which credits the seller off-chain instead. Reading the seller off that beneficiary attributed every
+ * such sale to the treasury: the seller's own sales vanished from `/v1/sales?seller=`, and
+ * `updateCreatorsSupportedSet` recorded the treasury rather than the creator the buyer actually supported.
+ *
+ * So the counterparty on the paid side comes from the trade itself, which no beneficiary can redirect —
+ * an Order is signed by its seller, and a Bid is accepted (called) by its seller.
+ *
+ * Historical rows are unaffected: where nobody redirected the payment, the payment beneficiary and the
+ * signer/caller are the same address, so a reindex reproduces them identically.
+ */
 export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
   const tradeType = getTradeEventType(event, network);
   if (tradeType === TradeType.Order) {
@@ -68,7 +87,9 @@ export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
         Number(event._trade.sent[0].assetType) === TradeAssetType.ITEM
           ? event._trade.sent[0].value
           : undefined,
-      seller: event._trade.received[0].beneficiary,
+      // The listing's signer. NOT received[0].beneficiary — that is whoever the payment was directed to,
+      // which the Shop points at the platform treasury.
+      seller: event._trade.signer,
       buyer: event._trade.sent[0].beneficiary,
       price: event._trade.received[0].value,
       assetType: event._trade.sent[0].assetType,
@@ -84,7 +105,10 @@ export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
         Number(event._trade.received[0].assetType) === TradeAssetType.ITEM
           ? event._trade.received[0].value
           : undefined,
-      seller: event._trade.sent[0].beneficiary,
+      // A bid is signed by the buyer and ACCEPTED by the seller, so the caller is the seller. Same
+      // reasoning as the Order branch above, applied to the other direction: sent[0].beneficiary is
+      // where the MANA goes, which is not necessarily who sold.
+      seller: event._caller,
       buyer: event._trade.received[0].beneficiary,
       price: event._trade.sent[0].value,
       assetType: event._trade.received[0].assetType,


### PR DESCRIPTION
## What broke

A shop secondary sale on Amoy was recorded as:

```
squid_marketplace.sale
  seller = 0x3eed…ad69      ← the platform treasury
  buyer  = 0x747c6f50…
```

The seller's activity feed calls `GET /v1/sales?seller=<them>`, which returned `total: 0`. They got the "Item Sold" notification, then found nothing in their history.

## Why

`getTradeEventData` read the seller off the payment leg's beneficiary:

```ts
seller: event._trade.received[0].beneficiary
```

`sent` / `received` are written from the **signer's** perspective, and a `beneficiary` answers *"who receives this asset"*. On the payment leg that is *"who gets paid"* — which equalled *"who sold"* only for as long as nobody redirected a payment.

The Shop redirects it. It signs listings whose payment beneficiary is the platform treasury, and credits the seller off-chain in shop credits instead. The address in that field stopped being the seller.

## Blast radius beyond the activity feed

Anything keyed on `sale.seller` was reassigned to the treasury. Notably `updateCreatorsSupportedSet(creatorsSupported, seller)` — every buyer of a shop listing got the treasury added to their "creators supported" set rather than the creator they actually supported. Downstream analytics that attribute earnings or sales per creator inherit the same error.

Currently one row on dev. This must not reach mainnet.

## The fix

The counterparty on the paid side now comes from the trade itself, which no beneficiary can redirect:

| | before | after |
|---|---|---|
| Order `seller` | `received[0].beneficiary` | `_trade.signer` |
| Bid `seller` | `sent[0].beneficiary` | `_caller` |

An order is signed by its seller; a bid is accepted (called) by its seller. Both fields are already on the `Traded` event.

`buyer` is deliberately **unchanged** in both directions: it is read from the *asset* leg, where the beneficiary genuinely is the recipient. Only the payment leg is redirectable, so only the payment leg was wrong.

The Bid change is a guard rather than a fix — no bid redirects its payment today. It keeps the invariant true if the Shop ever routes bid proceeds too, which is the same trap one direction over.

## Safe to reindex

Where nobody redirects the payment, the signer/caller and the payment beneficiary are the same address. So every historical row reproduces identically under this mapping, and a reindex also corrects the bad dev row. No coordination with other services needed.

## Tests

`src/common/utils/marketplaceV3.test.ts`, 5 tests via the repo's `node --test` setup:

- Order: attributes to the signer when the payment went to the treasury *(fails on current `main`)*
- Order: unchanged when the seller is paid directly — the historical-equivalence guard
- Order: buyer and price still read off the asset leg
- Bid: attributes to the accepting caller when the payment was redirected *(fails on current `main`)*
- Bid: unchanged when the seller is paid directly

**Verified 2 of the 5 fail against the current mapping and all 5 pass with the change.** The three that pass either way are exactly the ones asserting nothing changes for existing data.