### PR TITLE
fix: read a bid's seller from the payment beneficiary again

### DIFF
--- a/src/common/utils/marketplaceV3.test.ts
+++ b/src/common/utils/marketplaceV3.test.ts
@@ -7,6 +7,7 @@ process.env.POLYGON_CHAIN_ID = "80002";
 
 import { Network } from "@dcl/schemas";
 
+import { TradedEventArgs } from "../../abi/DecentralandMarketplaceEthereum";
 import { getTradeEventData, TradeAssetType } from "./marketplaceV3";
 import { MANA } from "../../polygon/addresses/amoy";
 
@@ -23,6 +24,8 @@ const SELLER = "0x2a4f9a28ba76413ef182351d864cc2916e462c3b";
 const BUYER = "0x747c6f502272129bf1ba872a1903045b837ee86c";
 const TREASURY = "0x3eedeceafa4797d36819c1d9f8e3b0071285ad69";
 const COLLECTION = "0x03b1940d80394614a5ba60abbf73fa749068bdad";
+/** The CreditsManager on Amoy — the msg.sender for every credits-funded purchase. */
+const CONTRACT = "0x8052a560e6e6ac86eeb7e711a4497f639b322fb3";
 
 type Asset = {
   assetType: number;
@@ -55,7 +58,7 @@ const tradedEvent = (opts: {
     _caller: opts.caller,
     _signature: "0x" + "0".repeat(64),
     _trade: { signer: opts.signer, sent: opts.sent, received: opts.received },
-  } as never);
+  } as unknown as TradedEventArgs);
 
 describe("getTradeEventData — sale attribution", () => {
   describe("an order (a listing, signed by its seller)", () => {
@@ -66,6 +69,24 @@ describe("getTradeEventData — sale attribution", () => {
       const event = tradedEvent({
         signer: SELLER,
         caller: BUYER,
+        sent: [asset({ beneficiary: BUYER })],
+        received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
+      });
+
+      const data = getTradeEventData(event, Network.MATIC);
+
+      assert.strictEqual(data.seller, SELLER);
+      assert.strictEqual(data.buyer, BUYER);
+    });
+
+    it("should be immune to a contract standing in for msg.sender", () => {
+      // The exact shape of the sale that exposed all of this on dev: paid with credits, so the
+      // CreditsManager forwarded `accept()` and msg.sender was neither party. The signer is recovered
+      // from the signature, so mediation cannot touch it — which is why the order branch reads it and
+      // the bid branch (where no signed field names the seller) cannot.
+      const event = tradedEvent({
+        signer: SELLER,
+        caller: CONTRACT,
         sent: [asset({ beneficiary: BUYER })],
         received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
       });
@@ -108,14 +129,16 @@ describe("getTradeEventData — sale attribution", () => {
     });
   });
 
-  describe("a bid (signed by its buyer, accepted by its seller)", () => {
-    it("should attribute the sale to the caller who accepted, not to whoever was paid", () => {
-      // The same hazard mirrored. No bid redirects its payment today, so this is a guard rather than a
-      // fix — it keeps the invariant true if the Shop ever routes bid proceeds too.
+  describe("a bid (signed by its buyer — the seller is not in the signed trade)", () => {
+    it("should read the seller from the payment beneficiary, not from msg.sender", () => {
+      // THE case `_caller` got wrong. A CreditsManager or a meta-transaction relay sits between the
+      // seller and the marketplace, so msg.sender is a CONTRACT — attributing the sale to it. Measured
+      // on dev, that already happens for 7 of 42 order sales and 144 of 256 mints; bids are only spared
+      // because nothing mediates them yet.
       const event = tradedEvent({
         signer: BUYER,
-        caller: SELLER,
-        sent: [manaAsset(TREASURY)],
+        caller: CONTRACT,
+        sent: [manaAsset(SELLER)],
         received: [asset({ beneficiary: BUYER })],
       });
 
@@ -125,7 +148,9 @@ describe("getTradeEventData — sale attribution", () => {
       assert.strictEqual(data.buyer, BUYER);
     });
 
-    it("should be unchanged when the seller is paid directly", () => {
+    it("should read the seller from the payment beneficiary when they called directly", () => {
+      // Every bid on dev today (22/22): caller and payment beneficiary are the same address, so this
+      // holds either way. It is here to pin that the reindex is a no-op for existing bid rows.
       const event = tradedEvent({
         signer: BUYER,
         caller: SELLER,

--- a/src/common/utils/marketplaceV3.ts
+++ b/src/common/utils/marketplaceV3.ts
@@ -68,11 +68,16 @@ export const getTradeEventType = (
  * such sale to the treasury: the seller's own sales vanished from `/v1/sales?seller=`, and
  * `updateCreatorsSupportedSet` recorded the treasury rather than the creator the buyer actually supported.
  *
- * So the counterparty on the paid side comes from the trade itself, which no beneficiary can redirect —
- * an Order is signed by its seller, and a Bid is accepted (called) by its seller.
+ * An order's seller therefore comes from `_trade.signer`, which is recovered from the EIP-712 signature
+ * and cannot be redirected by anything in the trade.
  *
- * Historical rows are unaffected: where nobody redirected the payment, the payment beneficiary and the
- * signer/caller are the same address, so a reindex reproduces them identically.
+ * A bid has no such field — a bid is signed by its BUYER, so the seller appears nowhere in the signed
+ * trade — and `msg.sender` is not a substitute, because a contract is routinely in between (see the Bid
+ * branch). It keeps reading the payment beneficiary, which is correct until something redirects a bid's
+ * payment; nothing does.
+ *
+ * Historical rows are unaffected: with no redirection the signer and the payment beneficiary are the
+ * same address, so a reindex reproduces them identically.
  */
 export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
   const tradeType = getTradeEventType(event, network);
@@ -105,10 +110,22 @@ export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
         Number(event._trade.received[0].assetType) === TradeAssetType.ITEM
           ? event._trade.received[0].value
           : undefined,
-      // A bid is signed by the buyer and ACCEPTED by the seller, so the caller is the seller. Same
-      // reasoning as the Order branch above, applied to the other direction: sent[0].beneficiary is
-      // where the MANA goes, which is not necessarily who sold.
-      seller: event._caller,
+      // Where the MANA goes. `_caller` looks like the better answer — a bid IS accepted by its seller —
+      // but only when the seller calls the marketplace directly. `msg.sender` is a CONTRACT whenever the
+      // acceptance is mediated: the CreditsManager forwards `accept()` for credits purchases, and the
+      // dapps send `executeMetaTransaction` through a relay. Measured on dev: of 42 order sales the
+      // caller is the buyer 35 times and some other address 7 times; of 256 mints it is neither party
+      // 144 times. Bids are simply the case that has not been mediated yet (22/22 called by the seller).
+      //
+      // So the two candidates fail in opposite situations, and this one's does not exist yet: the
+      // beneficiary is wrong only if a bid's payment is REDIRECTED, which nothing does today, whereas
+      // `_caller` is wrong as soon as anything mediates the call — already routine everywhere else.
+      //
+      // Unlike an order, a bid's seller is not in the signed trade at all (the BUYER signs a bid), so no
+      // on-chain field identifies them once a contract sits in between. If the Shop ever routes bid
+      // proceeds to the treasury, resolve the seller from the off-chain trade record — which knows both
+      // counterparties — rather than from another guess on this event.
+      seller: event._trade.sent[0].beneficiary,
       buyer: event._trade.received[0].beneficiary,
       price: event._trade.sent[0].value,
       assetType: event._trade.received[0].assetType,


### PR DESCRIPTION
Follow-up to #95, acting on its **[P2] Theoretical relay risk on Bid path**. Checked it against the data — it is not theoretical, and the guard I added is worse than what it replaced. Reverting that half; the order fix stands.

## Why `_caller` is wrong

#95 changed the bid branch to `event._caller`, reasoning that a bid is accepted by its seller. True — but only when the seller calls the marketplace **directly**. A contract is routinely in between:

- the **CreditsManager** forwards `accept()` for every credits-funded purchase;
- the dapps send **`executeMetaTransaction`** through a relay (`shop/app/src/lib/buy.ts:129`, and the contract exposes `executeMetaTransaction` + `MetaTransactionExecuted`).

The review noted "no relay is deployed today". Joining `squid_marketplace.sale` to `squid_trades.trade` on dev says otherwise:

| type | total | `caller`=seller | `caller`=buyer | `caller`=**neither** |
|---|---|---|---|---|
| bid | 22 | 22 | 0 | 0 |
| order | 42 | 0 | 35 | **7** |
| mint | 256 | 1 | 111 | **144** |

`_caller` is already neither counterparty for 7 of 42 order sales and 144 of 256 mints. Bids are simply the case nothing mediates *yet* — and the moment one is accepted through the CreditsManager, the seller becomes a contract address.

That inverts the trade-off. The beneficiary is wrong only if a bid's payment is **redirected**, which nothing does today. `_caller` is wrong as soon as anything **mediates the call**, which is already routine everywhere else. I swapped a field that is right 22/22 for one whose failure mode is live.

## What this changes

| | #95 | here |
|---|---|---|
| Order `seller` | `_trade.signer` | `_trade.signer` — unchanged |
| Bid `seller` | `_caller` | `sent[0].beneficiary` — restored |

The order branch is untouched and remains correct: `_trade.signer` is recovered from the EIP-712 signature, so no contract standing in for `msg.sender` can affect it. That asymmetry is the real lesson — an order names its seller in the signed trade, a bid does not (a bid is signed by its **buyer**), so there is no on-chain answer for a mediated bid at all.

If the Shop ever routes bid proceeds to the treasury, the seller should be resolved from the **off-chain trade record**, which knows both counterparties — not from another guess on this event. Noted in the code.

## Tests

6 tests (was 5). The bid pair now pins the correct behaviour, and the new order test covers the case that started all of this:

- **Order, caller = CreditsManager** *(new)* — the exact shape of the dev sale that exposed the original bug: credits-funded, so `msg.sender` was neither party. Passes, because the signer is cryptographic.
- **Bid, caller = CreditsManager** — **fails against current `main`** (attributes the sale to the contract), passes here.
- **Bid, caller = seller** — 22/22 of dev's real bids. Holds either way; it is there to pin that a reindex is a no-op for existing bid rows.

**Verified 1 of the 6 fails on current `main` and all 6 pass here.**

## Reindex

Safe either way — no existing bid row changes, since all 22 have `caller == sent[0].beneficiary`. The reindex already running for #95 does not need to be restarted; it is correcting order attribution, which is the part that was actually broken.

## Not addressed

The other two P2s from #95 are untouched: the `undefined` `tradeType` falling into the bid branch (pre-existing; hardening it changes the return contract, so it wants its own PR) and the missing `ITEM` assetType coverage. The `as never` cast is fixed here.