### PR TITLE
fix: index a Traded event whose sent or received leg is empty

### DIFF
--- a/src/common/utils/marketplaceV3.test.ts
+++ b/src/common/utils/marketplaceV3.test.ts
@@ -60,6 +60,20 @@ const tradedEvent = (opts: {
     _trade: { signer: opts.signer, sent: opts.sent, received: opts.received },
   } as unknown as TradedEventArgs);
 
+/**
+ * `getTradeEventData` returns undefined for a trade this squid does not index (see the giveaway tests
+ * at the bottom). Every test above is about a trade that IS indexed, so narrow it once here rather
+ * than asserting non-null in each one.
+ */
+const indexable = (
+  event: TradedEventArgs,
+  network: Parameters<typeof getTradeEventData>[1]
+) => {
+  const data = getTradeEventData(event, network);
+  assert.ok(data, "expected an indexable trade");
+  return data;
+};
+
 describe("getTradeEventData — sale attribution", () => {
   describe("an order (a listing, signed by its seller)", () => {
     it("should attribute the sale to the signer, not to whoever was paid", () => {
@@ -73,7 +87,7 @@ describe("getTradeEventData — sale attribution", () => {
         received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.seller, SELLER);
       assert.strictEqual(data.buyer, BUYER);
@@ -91,7 +105,7 @@ describe("getTradeEventData — sale attribution", () => {
         received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.seller, SELLER);
       assert.strictEqual(data.buyer, BUYER);
@@ -107,7 +121,7 @@ describe("getTradeEventData — sale attribution", () => {
         received: [manaAsset(SELLER)],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.seller, SELLER);
       assert.strictEqual(data.buyer, BUYER);
@@ -121,7 +135,7 @@ describe("getTradeEventData — sale attribution", () => {
         received: [manaAsset(TREASURY, TradeAssetType.USD_PEGGED_MANA)],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.collectionAddress, COLLECTION);
       assert.strictEqual(data.tokenId, 42n);
@@ -142,7 +156,7 @@ describe("getTradeEventData — sale attribution", () => {
         received: [asset({ beneficiary: BUYER })],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.seller, SELLER);
       assert.strictEqual(data.buyer, BUYER);
@@ -158,10 +172,69 @@ describe("getTradeEventData — sale attribution", () => {
         received: [asset({ beneficiary: BUYER })],
       });
 
-      const data = getTradeEventData(event, Network.MATIC);
+      const data = indexable(event, Network.MATIC);
 
       assert.strictEqual(data.seller, SELLER);
       assert.strictEqual(data.buyer, BUYER);
     });
+  });
+});
+
+/**
+ * A trade with an EMPTY leg.
+ *
+ * A giveaway — the signer hands over an asset and takes no payment — is accepted by the contract and
+ * emits `Traded` with `received: []`. Two such trades landed in Polygon block 91576312 and crash-looped
+ * the polygon processor: it read `received[0].assetType` on `undefined`, which is fatal inside the batch
+ * transaction, so it stopped indexing everything behind that block.
+ */
+describe("getTradeEventData — a trade with no payment leg", () => {
+  it("should not throw when `received` is empty", () => {
+    const event = tradedEvent({
+      signer: SELLER,
+      caller: CONTRACT,
+      sent: [asset({ beneficiary: BUYER })],
+      received: [],
+    });
+
+    assert.doesNotThrow(() => getTradeEventData(event, Network.MATIC));
+  });
+
+  it("should not throw when `sent` is empty", () => {
+    const event = tradedEvent({
+      signer: SELLER,
+      caller: CONTRACT,
+      sent: [],
+      received: [manaAsset(SELLER)],
+    });
+
+    assert.doesNotThrow(() => getTradeEventData(event, Network.MATIC));
+  });
+
+  it("should report a giveaway as not indexable rather than inventing a bid", () => {
+    // The `else` branch used to catch both "it is a bid" and "we could not tell". A giveaway has no
+    // price and no seller to read, so treating it as a bid would write both as fiction.
+    const event = tradedEvent({
+      signer: SELLER,
+      caller: CONTRACT,
+      sent: [asset({ beneficiary: BUYER })],
+      received: [],
+    });
+
+    assert.strictEqual(getTradeEventData(event, Network.MATIC), undefined);
+  });
+
+  it("should still classify a normal order, so the guard costs nothing", () => {
+    const event = tradedEvent({
+      signer: SELLER,
+      caller: CONTRACT,
+      sent: [asset({ beneficiary: BUYER })],
+      received: [manaAsset(TREASURY)],
+    });
+
+    const data = indexable(event, Network.MATIC);
+
+    assert.strictEqual(data.seller, SELLER);
+    assert.strictEqual(data.buyer, BUYER);
   });
 });

--- a/src/common/utils/marketplaceV3.ts
+++ b/src/common/utils/marketplaceV3.ts
@@ -28,18 +28,29 @@ export const getTradeEventType = (
 ): TradeType | undefined => {
   const addresses = getAddresses(network);
 
+  // Either leg can be EMPTY. A trade that sends an asset and receives nothing is a giveaway: valid
+  // on-chain (the contract accepts it and emits Traded), and neither an order nor a bid — there is no
+  // payment leg to classify. Reading `[0]` unguarded threw inside the batch transaction, which the
+  // processor treats as fatal: it crash-looped on the block and stopped indexing everything behind it
+  // (prod, 2026-08-07). Falling through to `undefined` is the existing "not a trade we index" answer.
+  const sent = event._trade.sent[0];
+  const received = event._trade.received[0];
+  if (!sent || !received) {
+    return undefined;
+  }
+
   // We're only supporting the case of one trade for the moment. We could have multiple trades in the future.
   // A MANA payment leg is either plain ERC20 MANA or USD-pegged MANA (the credits/Shop checkout) — both
   // must be recognized, otherwise a credits sale is misclassified and its collection/tokenId are read off
   // the wrong asset, so the mint never gets indexed.
   const isReceivingMana = MANA_PAYMENT_ASSET_TYPES.includes(
-    Number(event._trade.received[0].assetType)
+    Number(received.assetType)
   );
   const isSendingMana = MANA_PAYMENT_ASSET_TYPES.includes(
-    Number(event._trade.sent[0].assetType)
+    Number(sent.assetType)
   );
-  const contractAddressReceived = event._trade.received[0].contractAddress;
-  const contractAddressSent = event._trade.sent[0].contractAddress;
+  const contractAddressReceived = received.contractAddress;
+  const contractAddressSent = sent.contractAddress;
 
   // if received is MANA, then it's an order. We could also have other ERC20 sent, but for the moment we are only checking for MANA
   if (
@@ -81,6 +92,12 @@ export const getTradeEventType = (
  */
 export const getTradeEventData = (event: TradedEventArgs, network: Network) => {
   const tradeType = getTradeEventType(event, network);
+  // An unclassifiable trade used to fall through to the Bid branch, because the `else` caught both "it
+  // is a bid" and "we could not tell". Those are different answers: a giveaway has no payment leg, so
+  // reading a price and a seller off it invents both. Return nothing and let the callers skip it.
+  if (tradeType === undefined) {
+    return undefined;
+  }
   if (tradeType === TradeType.Order) {
     return {
       collectionAddress: event._trade.sent[0].contractAddress,

--- a/src/eth/handlers/marketplace.ts
+++ b/src/eth/handlers/marketplace.ts
@@ -189,6 +189,10 @@ export async function handleTraded(
 ): Promise<void> {
   const tradeType = getTradeEventType(event, Network.ETHEREUM);
   const tradeData = getTradeEventData(event, Network.ETHEREUM);
+  // Nothing to index: not an order or a bid (a giveaway has no payment leg).
+  if (!tradeData) {
+    return;
+  }
   const { collectionAddress, price, buyer, seller, tokenId } = tradeData;
 
   if (!tokenId) {

--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -613,6 +613,10 @@ run(dataSource, db, async (simpleCtx) => {
           case MarketplaceV3ABI.events.Traded.topic: {
             const event = MarketplaceV3ABI.events.Traded.decode(log);
             const tradeData = getTradeEventData(event, Network.ETHEREUM);
+            // Nothing to index: not an order or a bid (a giveaway has no payment leg).
+            if (!tradeData) {
+              break;
+            }
             const { collectionAddress, tokenId, buyer, seller } = tradeData;
 
             if (!tokenId) {

--- a/src/polygon/handlers/marketplace.ts
+++ b/src/polygon/handlers/marketplace.ts
@@ -248,6 +248,10 @@ export async function handleTraded(
 
   const tradeData = getTradeEventData(event, Network.MATIC);
   const tradeType = getTradeEventType(event, Network.MATIC);
+  // Nothing to index: not an order or a bid (a giveaway has no payment leg).
+  if (!tradeData) {
+    return;
+  }
   const { assetType, collectionAddress, tokenId, buyer, price, seller } =
     tradeData;
   const marketplaceV3Contract = new MarketplaceV3ABI.Contract(

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -1164,6 +1164,10 @@ run(dataSource, db, async (simpleCtx) => {
           case MarketplaceV3ABI.events.Traded.topic: {
             const event = MarketplaceV3ABI.events.Traded.decode(log);
             const tradeData = getTradeEventData(event, Network.MATIC);
+            // Nothing to index: not an order or a bid (a giveaway has no payment leg).
+            if (!tradeData) {
+              break;
+            }
             const { collectionAddress, buyer, seller, assetType, itemId } =
               tradeData;
             let tokenId = tradeData.tokenId;


### PR DESCRIPTION
## The outage

The polygon processor is crash-looping and has indexed nothing since block **91576311**:

```
FATAL sqd:processor TypeError: Cannot read properties of undefined (reading 'assetType')
  at getTradeEventType (/squid/lib/common/utils/marketplaceV3.js:19:62)
  at getTradeEventData (/squid/lib/common/utils/marketplaceV3.js:36:53)
```

It restarts, resumes, replays block **91576312**, dies. Same block, same trade, and the same root cause that took down `trades-squid-core` at the same minute (decentraland/trades-squid-core#41) — two independent consumers of one event, both assuming the same thing.

## What is in that block

```ts
const isReceivingMana = MANA_PAYMENT_ASSET_TYPES.includes(
  Number(event._trade.received[0].assetType)   // received is []
);
```

Two `Traded` logs on Polygon are shaped `sent: 1, received: 0` — block 91576312 (`0x196fd4ad…c9289`) and block 91578006 (`0x91a3180b…7c07f`). Decoding the full receipts: a plain ERC721 `Transfer` from the signer to the beneficiary, no MANA leg anywhere. A **giveaway** — the signer hands over an asset and takes no payment. Both relayed through the DCL meta-tx relayer, same signer, same beneficiary.

The contract accepts it and emits `Traded`, so this is valid on-chain data the indexer has to survive. Nothing here is a regression from a recent PR; the trade shape is simply new.

## The fix

**1. `getTradeEventType` no longer throws.** Either leg may be empty, and a trade with no payment leg is neither an order nor a bid, so it returns `undefined` — the function's existing "not something we index" answer.

**2. `getTradeEventData` returns `undefined` for it.** This is the second bug and it is a correctness one, not just a crash: the `else` branch caught *both* "it is a bid" and "we could not classify it". A giveaway has no price and no seller to read, so the Bid branch would have written both as fiction — `price` off a nonexistent payment leg, `seller` off a nonexistent beneficiary. Even with the guard in (1), that path would have produced a garbage `Sale` row instead of a crash.

**3. All four call sites skip an unindexable trade** — `polygon/main.ts`, `polygon/handlers/marketplace.ts`, `eth/main.ts`, `eth/handlers/marketplace.ts` — rather than destructuring `undefined`.

## Tests

`marketplaceV3.test.ts`, 15 passing. New: does not throw on an empty `received`; does not throw on an empty `sent`; reports a giveaway as not-indexable rather than inventing a bid; and still classifies a normal order, so the guard costs nothing.

The existing attribution tests now go through an `indexable()` helper that asserts non-null once, since `getTradeEventData` is `Data | undefined` from here on.

## Deploying without a reindex

The processor stores its cursor in the squid's own schema, and it already reports it on every restart (`last processed final block was 91575810`). A new image pointed at the **same** `DB_URL` and schema resumes from there — no reindex. What must not happen is provisioning a fresh schema/deployment slot, which would restart from `fromBlock` and take days on this squid.

## Follow-up

Both squids died on the same field of the same event within seconds of each other. Any consumer that decodes `Traded` and indexes `sent[0]` / `received[0]` has this bug; worth a sweep rather than waiting for the next one to page someone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyGCPEq4PxTSefUeBw6yX1
