### PR TITLE
fix: ingest from the shared Portal endpoint with an api key

### DIFF
--- a/src/common/utils/portal.ts
+++ b/src/common/utils/portal.ts
@@ -1,0 +1,34 @@
+import { assertNotNull } from "@subsquid/util-internal";
+
+const DEFAULT_PORTAL_HOST = "https://shared.portal.sqd.dev";
+
+/**
+ * The SQD Network Portal stream this squid ingests from.
+ *
+ * The SHARED portal, not the public one, and the difference is not cosmetic. A Portal query is
+ * capped at 256 KiB, and our Polygon log filter carries the full list of DCL collection addresses
+ * — ~260 KB today and growing with every collection published. Over the public endpoint that query
+ * is rejected with `400 Query is too large` and the processor never ingests a single block, which
+ * is what stalled the Polygon reindex for two weeks. The shared endpoint raises the cap; it is
+ * authenticated, so it also needs the key.
+ *
+ * The host is overridable because the endpoint has already moved once: a replacement should not
+ * require shipping new code. The key is env-only and must never be committed.
+ */
+export function portalSource(dataset: string): {
+  url: string;
+  http: { headers: Record<string, string> };
+} {
+  const host = process.env.SQD_PORTAL_URL || DEFAULT_PORTAL_HOST;
+  return {
+    url: `${host}/datasets/${dataset}`,
+    http: {
+      headers: {
+        "x-api-key": assertNotNull(
+          process.env.SQD_API_KEY,
+          "SQD_API_KEY is not set — the shared Portal endpoint is authenticated"
+        ),
+      },
+    },
+  };
+}

--- a/src/eth/processor.ts
+++ b/src/eth/processor.ts
@@ -1,5 +1,6 @@
 import { ChainId, Network } from "@dcl/schemas";
 import { assertNotNull } from "@subsquid/util-internal";
+import { portalSource } from "../common/utils/portal";
 import { DataSourceBuilder, FieldSelection } from "@subsquid/evm-stream";
 import * as evmObjects from "@subsquid/evm-objects";
 import { RpcClient } from "@subsquid/rpc-client";
@@ -20,8 +21,9 @@ import * as SpokeABI from "../abi/Spoke";
 const addresses = getAddresses(Network.ETHEREUM);
 const chainId = process.env.ETHEREUM_CHAIN_ID || ChainId.ETHEREUM_MAINNET;
 
-// SQD Network Portal dataset (replaces the deprecated v2 archive gateway).
-const PORTAL_URL = `https://portal.sqd.dev/datasets/ethereum-${
+// SQD Network Portal dataset (replaces the deprecated v2 archive gateway). See portalSource for
+// why this is the shared endpoint and not the public one.
+const PORTAL_DATASET = `ethereum-${
   chainId == ChainId.ETHEREUM_MAINNET ? "mainnet" : "sepolia"
 }`;
 const RPC_ENDPOINT = process.env.RPC_ENDPOINT_ETH;
@@ -89,7 +91,7 @@ const erc721TransferTopics = [
 ];
 
 export const dataSource = new DataSourceBuilder()
-  .setPortal(PORTAL_URL)
+  .setPortal(portalSource(PORTAL_DATASET))
   .setBlockRange({ from: FROM_BLOCK })
   .setFields(fields)
   .addLog({

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -1,4 +1,5 @@
 import { assertNotNull } from "@subsquid/util-internal";
+import { portalSource } from "../common/utils/portal";
 import { DataSourceBuilder, FieldSelection } from "@subsquid/evm-stream";
 import * as evmObjects from "@subsquid/evm-objects";
 import { RpcClient } from "@subsquid/rpc-client";
@@ -26,8 +27,9 @@ import { startBlockByNetwork } from "./addresses/startBlocks";
 const addresses = getAddresses(Network.MATIC);
 const chainId = process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET;
 
-// SQD Network Portal dataset (replaces the deprecated v2 archive gateway).
-const PORTAL_URL = `https://portal.sqd.dev/datasets/polygon-${
+// SQD Network Portal dataset (replaces the deprecated v2 archive gateway). See portalSource for
+// why this is the shared endpoint and not the public one.
+const PORTAL_DATASET = `polygon-${
   chainId == ChainId.MATIC_MAINNET ? "mainnet" : "amoy-testnet"
 }`;
 const RPC_ENDPOINT = process.env.RPC_ENDPOINT_POLYGON;
@@ -98,7 +100,7 @@ const collectionV2Topics = [
 ];
 
 export const dataSource = new DataSourceBuilder()
-  .setPortal(PORTAL_URL)
+  .setPortal(portalSource(PORTAL_DATASET))
   .setBlockRange(getBlockRange(Network.MATIC))
   .setFields(fields)
   .addLog({


### PR DESCRIPTION
## The problem

The public Portal caps a query body at **256 KiB**. Our Polygon log filter carries the full list of DCL collection addresses — ~260 KB today and growing with every collection published — so the query is ~1.4 KB over and the stream answers:

```
400 Bad request: Query is too large
```

The processor then never ingests a single block. That is why the Polygon reindex on the idle slot sat at 0% for two weeks while Ethereum (whose filter is small) synced normally the same day.

The address filter cannot be dropped: without it the events we need are matched by `Transfer(address,address,uint256)`, whose topic0 every ERC20/ERC721 on Polygon shares. Measured over a 10k-block window that is 720 bytes returned with the filter versus 44 MB without — a full backfill becomes petabyte-scale. Chunking does not help either; the stream SDK merges `addLog` calls back into one query.

SQD raised the cap on their **shared** endpoint, which is authenticated.

## The change

`src/common/utils/portal.ts` — one place that builds the Portal connection, used by both processors:

```ts
url:  `${process.env.SQD_PORTAL_URL || "https://shared.portal.sqd.dev"}/datasets/${dataset}`
http: { headers: { "x-api-key": assertNotNull(process.env.SQD_API_KEY, "…") } }
```

- **Host is overridable** via `SQD_PORTAL_URL`. This endpoint has already moved once (`portal.sqd.dev` → `shared.portal.sqd.dev`); a third move should not need a code deploy, a rebuilt image and a new schema.
- **The key is env-only.** Never in the repo, never in an image.
- `assertNotNull` makes a missing key a **boot failure with a named cause**, matching how `RPC_ENDPOINT_*` is already handled here. The alternative — starting and taking 401s mid-batch — reads as a network flake and costs an hour to trace.

## ⚠️ Required before deploying

**`SQD_API_KEY` must be set in the service environment.** Without it the processor exits at startup with `SQD_API_KEY is not set — the shared Portal endpoint is authenticated`.

## Deliberately not changed

`src/polygon/tools/collectionsRetriever.ts` still points at the public endpoint. Its query is only the factory's `ProxyCreated` events — no address list, nowhere near the cap — and its comment states the property on purpose: *"The Portal needs no key, so this can be run by anyone (and by CI) without a secret."* Requiring a key there would trade a working property for consistency that buys nothing.

## Verified

`npm test` — 15/15 pass, and the build (`tsc` over the whole repo) is clean, so both call sites typecheck against the `setPortal` object form.

Not verified here: an actual authenticated request. That happens on the first deploy to the idle slot, where the signal is unambiguous — either blocks start flowing or the `400 Query is too large` returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyGCPEq4PxTSefUeBw6yX1
