### PR TITLE
fix: read the Portal key from the variable that is actually wired

### DIFF
--- a/src/common/utils/portal.ts
+++ b/src/common/utils/portal.ts
@@ -20,13 +20,23 @@ export function portalSource(dataset: string): {
   http: { headers: Record<string, string> };
 } {
   const host = process.env.SQD_PORTAL_URL || DEFAULT_PORTAL_HOST;
+  // Today the key arrives as SQUID_API_KEY: that is the variable already wired to every squid
+  // service (SSM `ops-param-subsquid-api-key`), and that parameter now holds the Portal key.
+  //
+  // TRANSITIONAL. The same variable is what the pre-Portal trades squid still passes to the v2
+  // archive as `setGateway({ apiKey })`, and those are two different SQD products with two
+  // different keys — one parameter cannot serve both. It works today only because a processor at
+  // the head reads from the RPC and only falls back to the archive when it drops far behind. Once
+  // trades is promoted onto its Portal build it stops needing the archive key entirely; give the
+  // Portal its own parameter then and drop the fallback below.
+  const apiKey = process.env.SQD_API_KEY || process.env.SQUID_API_KEY;
   return {
     url: `${host}/datasets/${dataset}`,
     http: {
       headers: {
         "x-api-key": assertNotNull(
-          process.env.SQD_API_KEY,
-          "SQD_API_KEY is not set — the shared Portal endpoint is authenticated"
+          apiKey,
+          "Neither SQD_API_KEY nor SQUID_API_KEY is set — the shared Portal endpoint is authenticated"
         ),
       },
     },


### PR DESCRIPTION
## Why

#100 reads `process.env.SQD_API_KEY`. **Nothing sets it.** `definitions` maps `SQUID_API_KEY` → SSM `ops-param-subsquid-api-key`, on all six squid services, and there is no `SQD_API_KEY` anywhere in that repo.

So the merged code fails at boot:

```
SQD_API_KEY is not set — the shared Portal endpoint is authenticated
```

The task still provisions its schema before dying, so each attempt leaves an orphan schema behind.

(The follow-up commit that fixed this was pushed to the #100 branch after it had already been squashed, so it did not land.)

## The change

```ts
const apiKey = process.env.SQD_API_KEY || process.env.SQUID_API_KEY
```

Prefer the explicit name; fall back to the one that is wired today. The SSM parameter behind `SQUID_API_KEY` now holds the Portal key, so this needs no `definitions` change and no `definitions` deploy — which is what unblocks the idle-slot reindex right now.

## The conflict this leaves, written into the code

`SQUID_API_KEY` is also what the **pre-Portal trades squid** passes to the deprecated v2 archive:

```ts
.setGateway({ url: "https://v2.archive.subsquid.io/…", apiKey: process.env.SQUID_API_KEY })
```

Those are two different SQD products with two different keys, and one SSM parameter cannot serve both. It works today only because a processor sitting at the head reads from the RPC (`using chain RPC data source` in the current logs) and only falls back to the archive when it drops far behind — which happened for six hours this morning, so it is not hypothetical.

The exit is already merged: trades on `main` uses `.setPortal(...)` with **no key** against the public endpoint (its query is small enough). Once trades is promoted onto that build it stops needing the archive key entirely — then give the Portal its own parameter and drop this fallback. The comment in `portal.ts` says exactly that, next to the code.

## Verified

`npm test` 15/15, `tsc` over the repo clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyGCPEq4PxTSefUeBw6yX1
