### PR TITLE
refactor: read collections concurrently instead of one at a time

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,12 @@ const BLOCK_RANGES: Record<string, { from: number }> = {
   },
 };
 
+// The chain the Polygon processor indexes. A bigint because that is what Collection.chainId
+// stores, and the single copy because reading it in each module invites the two to drift.
+export const POLYGON_CHAIN_ID = BigInt(
+  process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET
+);
+
 export const getBlockRange = (network: Network) => {
   const chainId =
     network === Network.ETHEREUM

--- a/src/eth/processor.ts
+++ b/src/eth/processor.ts
@@ -42,10 +42,13 @@ export type Fields = typeof fields;
 // RPC client for contract-state reads (owner(), tokenURI multicall, cuts, ...).
 // Portal only ingests logs/blocks; eth_call still goes through the RPC endpoint,
 // so Portal (data) and RPC (state) run as two independent channels.
+// Raised alongside Polygon's, for the same reason: 10 req/s throttles a from-scratch reindex
+// far below what the endpoint serves. Ethereum has Multicall3 from block 14_353_601, so it has
+// less per-collection RPC to begin with, but tokenURI and owner reads hit the same ceiling.
 export const rpc = new RpcClient({
   url: assertNotNull(RPC_ENDPOINT, "RPC_ENDPOINT_ETH is not set"),
-  capacity: 10,
-  rateLimit: 10,
+  capacity: 100,
+  rateLimit: 100,
 });
 
 export const logger: Logger = createLogger("sqd:eth");

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -1,4 +1,4 @@
-import { ChainId, Network } from "@dcl/schemas";
+import { Network } from "@dcl/schemas";
 import { getURNForCollectionV2 } from "../../common/utils/network";
 import { createOrLoadAccount } from "../../common/modules/account";
 import {
@@ -30,15 +30,12 @@ import { Log, Transaction } from "../processor";
 import { handleMintNFT, handleTransferNFT } from "./nft";
 import { isMint } from "../../common/utils";
 import { StoreContractData } from "../state";
+import { POLYGON_CHAIN_ID } from "../../config";
 import type { CollectionData } from "../utils/collectionMulticall";
 
 // Pre-fetched collection data from multicall (the multicall keys results by
 // address, so the per-collection payload is CollectionData without its `address`).
 export type PrefetchedCollectionData = Omit<CollectionData, "address">;
-
-const POLYGON_CHAIN_ID = BigInt(
-  process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET
-);
 
 export const handleCollectionCreation = async (
   ctx: Context,

--- a/src/polygon/handlers/collection.ts
+++ b/src/polygon/handlers/collection.ts
@@ -1,4 +1,4 @@
-import { Network } from "@dcl/schemas";
+import { ChainId, Network } from "@dcl/schemas";
 import { getURNForCollectionV2 } from "../../common/utils/network";
 import { createOrLoadAccount } from "../../common/modules/account";
 import {
@@ -36,6 +36,10 @@ import type { CollectionData } from "../utils/collectionMulticall";
 // address, so the per-collection payload is CollectionData without its `address`).
 export type PrefetchedCollectionData = Omit<CollectionData, "address">;
 
+const POLYGON_CHAIN_ID = BigInt(
+  process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET
+);
+
 export const handleCollectionCreation = async (
   ctx: Context,
   block: Block,
@@ -65,7 +69,9 @@ export const handleCollectionCreation = async (
     baseURI = prefetchedData.baseURI;
     chainId = prefetchedData.chainId;
   } else {
-    // Fallback: 9 RPC calls (only if multicall failed)
+    // Last resort, one collection at a time. The prefetch (multicall above the Multicall3
+    // deployment block, concurrent individual reads below it) covers every collection it can,
+    // so reaching this means that collection's reads failed there.
     const collectionContract = new CollectionV2ABI.Contract(ctx, block, address);
     const rpcStart = performance.now();
     const results = await Promise.all([
@@ -77,13 +83,14 @@ export const handleCollectionCreation = async (
       collectionContract.isApproved(),
       collectionContract.isEditable(),
       collectionContract.baseURI(),
-      collectionContract.getChainId(),
     ]);
     const rpcDuration = performance.now() - rpcStart;
     const fmt = (ms: number) => ms >= 1000 ? `${(ms/1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
     console.log(`⚠️ handleCollectionCreation RPC fallback for ${address.slice(0,10)}: ${fmt(rpcDuration)}`);
-    
-    [name, symbol, owner, creator, isCompleted, isApproved, isEditable, baseURI, chainId] = results;
+
+    [name, symbol, owner, creator, isCompleted, isApproved, isEditable, baseURI] = results;
+    // getChainId() returns block.chainid, always POLYGON_CHAIN_ID here — not worth an RPC call.
+    chainId = POLYGON_CHAIN_ID;
   }
 
   //   console.log("all gotten");

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -35,6 +35,7 @@ import * as CreditsManagerABI from "./abi/CreditsManager";
 import * as SpokeABI from "../abi/Spoke";
 import {
   fetchCollectionDataMulticall,
+  fetchCollectionDataDirect,
   type CollectionData,
 } from "./utils/collectionMulticall";
 import {
@@ -660,6 +661,19 @@ run(dataSource, db, async (simpleCtx) => {
         lastBlock,
         collectionAddresses
       );
+
+      // Below Polygon block 25_770_160 there is no Multicall3, so the call above returns nothing
+      // and every collection would otherwise be read one at a time INSIDE the handler loop below,
+      // which is sequential. Read whatever the multicall did not cover here instead, concurrently.
+      const missing = proxyCreatedEvents.filter(
+        (e) => !prefetchedCollectionData.has(e.address.toLowerCase())
+      );
+      if (missing.length > 0) {
+        const direct = await fetchCollectionDataDirect(ctx, missing);
+        for (const [address, data] of direct) {
+          prefetchedCollectionData.set(address, data);
+        }
+      }
 
       const multicallDuration = performance.now() - multicallStart;
       metrics.ownerMulticallTime = multicallDuration;

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -643,10 +643,10 @@ run(dataSource, db, async (simpleCtx) => {
 
     metrics.preIndexTime = performance.now() - preIndexStart;
 
-    // ⚡ OPTIMIZATION: Fetch ALL collection data via MULTICALL (9 calls per collection → 1 batch)
-    // This is the biggest optimization: instead of 9 RPC calls per collection,
-    // we fetch name, symbol, owner, creator, isCompleted, isApproved, isEditable, baseURI, chainId
-    // for ALL collections in a single multicall batch!
+    // Read every collection the batch creates up front — name, symbol, owner, creator,
+    // isCompleted, isApproved, isEditable, baseURI, at CALLS_PER_COLLECTION reads each. Above the
+    // Multicall3 deployment block that is a single batched call for all of them; below it, a
+    // concurrent direct read. Either way the handler loop further down is left free of I/O.
     let prefetchedCollectionData = new Map<string, CollectionData>();
 
     if (proxyCreatedEvents.length > 0) {

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -48,10 +48,15 @@ export type Fields = typeof fields;
 // RPC client for contract-state reads (owner(), the collection multicall, rarities,
 // item/store data). Portal only ingests logs/blocks; eth_call still goes through the
 // RPC endpoint, so Portal (data) and RPC (state) run as two independent channels.
+// 100 req/s, not 10. Below block 25_770_160 Multicall3 does not exist on Polygon, so every
+// collection created before it costs a handful of individual eth_calls (see
+// fetchCollectionDataDirect). At 10 req/s that throttle alone was 50s of a 65s batch during a
+// from-scratch reindex — more than the DB reads and writes put together. Measured against
+// rpc.decentraland.org: 100 concurrent eth_calls complete in ~356ms with no errors.
 export const rpc = new RpcClient({
   url: assertNotNull(RPC_ENDPOINT, "RPC_ENDPOINT_POLYGON is not set"),
-  capacity: 10,
-  rateLimit: 10,
+  capacity: 100,
+  rateLimit: 100,
 });
 
 export const logger: Logger = createLogger("sqd:polygon");

--- a/src/polygon/utils/collectionMulticall.ts
+++ b/src/polygon/utils/collectionMulticall.ts
@@ -1,15 +1,34 @@
+import { ChainId } from "@dcl/schemas";
 import { Multicall, AggregateTuple } from "../../abi/multicall";
-import { functions as CollectionV2Functions } from "../abi/CollectionV2";
+import {
+  Contract as CollectionV2Contract,
+  functions as CollectionV2Functions,
+} from "../abi/CollectionV2";
 import type { Context, Block } from "../processor";
 
-// Number of contract calls issued per collection in the multicall batch. Keep in
-// sync with the calls pushed below and the per-collection result slice.
-const CALLS_PER_COLLECTION = 9;
+// Number of contract calls issued per collection. Keep in sync with the calls pushed below,
+// the per-collection result slice, and readCollection.
+//
+// getChainId() is deliberately NOT one of them. It returns `block.chainid`, which for this
+// processor is always POLYGON_CHAIN_ID, so calling it spends one RPC per collection to learn a
+// constant we already have.
+const CALLS_PER_COLLECTION = 8;
+
+const CHAIN_ID = BigInt(process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET);
 
 const MULTICALL_CONTRACT = "0xcA11bde05977b3631167028862bE2a173976CA11";
-// Multicall3 on Polygon was deployed at block 25770160 (Jan 2022)
-// But we're indexing from much later, so it's always available
+// Multicall3 was deployed on Polygon at block 25770160. Everything BELOW it — the first ~28% of
+// the chain, and most of the collections ever created — has no multicall and must be read with
+// individual eth_calls, which is what fetchCollectionDataDirect is for.
 export const POLYGON_MULTICALL_CREATION_BLOCK = 25770160;
+
+// How many collections the direct path reads concurrently. Each issues CALLS_PER_COLLECTION
+// eth_calls, so this bounds the promise fan-out; the RPC client's own capacity/rateLimit is
+// what actually paces the requests.
+const DIRECT_FETCH_CONCURRENCY = 25;
+
+const fmt = (ms: number) =>
+  ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
 
 export interface CollectionData {
   address: string;
@@ -26,7 +45,7 @@ export interface CollectionData {
 
 /**
  * Fetch all collection data for multiple collections in a single multicall batch
- * This reduces 9 RPC calls per collection to 1 batch call for ALL collections
+ * This reduces CALLS_PER_COLLECTION RPC calls per collection to 1 batch call for ALL collections
  */
 export async function fetchCollectionDataMulticall(
   ctx: Context,
@@ -39,8 +58,7 @@ export async function fetchCollectionDataMulticall(
 
   // Check if we're past the multicall creation block
   if (blockHeader.height < POLYGON_MULTICALL_CREATION_BLOCK) {
-    console.log(`⚠️ Block ${blockHeader.height} is before multicall creation, falling back to individual calls`);
-    return new Map(); // Caller will use fallback
+    return new Map(); // Caller will use fetchCollectionDataDirect
   }
 
   const multicall = new Multicall(ctx, blockHeader, MULTICALL_CONTRACT);
@@ -48,7 +66,7 @@ export async function fetchCollectionDataMulticall(
 
   // Build all calls: CALLS_PER_COLLECTION functions x N collections
   const calls: AggregateTuple[] = [];
-  
+
   for (const address of collectionAddresses) {
     calls.push([CollectionV2Functions.name, address, {}]);
     calls.push([CollectionV2Functions.symbol, address, {}]);
@@ -58,18 +76,20 @@ export async function fetchCollectionDataMulticall(
     calls.push([CollectionV2Functions.isApproved, address, {}]);
     calls.push([CollectionV2Functions.isEditable, address, {}]);
     calls.push([CollectionV2Functions.baseURI, address, {}]);
-    calls.push([CollectionV2Functions.getChainId, address, {}]);
   }
 
   const multicallStart = performance.now();
-  
+
   try {
     // Use tryAggregate to handle individual failures gracefully
     const rawResults = await multicall.tryAggregate(calls, 100); // Page size of 100
-    
+
     const multicallDuration = performance.now() - multicallStart;
-    const fmt = (ms: number) => ms >= 1000 ? `${(ms/1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
-    console.log(`✅ Multicall for ${collectionAddresses.length} collections (${calls.length} calls): ${fmt(multicallDuration)}`);
+    console.log(
+      `✅ Multicall for ${collectionAddresses.length} collections (${
+        calls.length
+      } calls): ${fmt(multicallDuration)}`
+    );
 
     // Parse results: CALLS_PER_COLLECTION results per collection
     for (let i = 0; i < collectionAddresses.length; i++) {
@@ -80,9 +100,14 @@ export async function fetchCollectionDataMulticall(
       const allSuccess = rawResults
         .slice(baseIndex, baseIndex + CALLS_PER_COLLECTION)
         .every((r) => r.success);
-      
+
       if (!allSuccess) {
-        console.log(`⚠️ Multicall failed for collection ${address.slice(0, 10)}, will use fallback`);
+        console.log(
+          `⚠️ Multicall failed for collection ${address.slice(
+            0,
+            10
+          )}, will use fallback`
+        );
         continue;
       }
 
@@ -96,7 +121,7 @@ export async function fetchCollectionDataMulticall(
         isApproved: rawResults[baseIndex + 5].value as boolean,
         isEditable: rawResults[baseIndex + 6].value as boolean,
         baseURI: rawResults[baseIndex + 7].value as string,
-        chainId: rawResults[baseIndex + 8].value as bigint,
+        chainId: CHAIN_ID,
       });
     }
   } catch (e: any) {
@@ -108,3 +133,104 @@ export async function fetchCollectionDataMulticall(
   return results;
 }
 
+/**
+ * Read collection data with individual eth_calls, for the range where Multicall3 does not exist
+ * yet (Polygon below POLYGON_MULTICALL_CREATION_BLOCK).
+ *
+ * Collections are read CONCURRENTLY. They used to be read one after another inside the handler
+ * loop, which has to stay sequential because every handleCollectionCreation read-modify-writes
+ * shared storedData across awaits. That constraint applies to the state mutation, not to the
+ * reads: doing them here first leaves the loop pure in-memory and lets the calls overlap. On a
+ * from-scratch reindex the serialized version was the single largest term in a batch — 50s of a
+ * 65s batch, more than the DB reads and writes combined.
+ *
+ * Each collection is read at ITS OWN creation block, exactly as the per-collection fallback in
+ * handleCollectionCreation does. That is stricter than the multicall path, which reads the whole
+ * batch at the batch's last block: owner/isCompleted/isApproved/isEditable are mutable, so the
+ * two are not interchangeable and this path keeps the stricter one.
+ *
+ * A collection whose reads fail is omitted rather than throwing — the caller still has the
+ * per-collection fallback.
+ */
+export async function fetchCollectionDataDirect(
+  ctx: Context,
+  collections: { address: string; blockHeader: Block }[]
+): Promise<Map<string, CollectionData>> {
+  const results = new Map<string, CollectionData>();
+  if (collections.length === 0) {
+    return results;
+  }
+
+  const start = performance.now();
+
+  for (let i = 0; i < collections.length; i += DIRECT_FETCH_CONCURRENCY) {
+    const chunk = collections.slice(i, i + DIRECT_FETCH_CONCURRENCY);
+    const settled = await Promise.allSettled(
+      chunk.map(({ address, blockHeader }) =>
+        readCollection(ctx, blockHeader, address)
+      )
+    );
+
+    settled.forEach((outcome, j) => {
+      if (outcome.status === "fulfilled") {
+        results.set(outcome.value.address, outcome.value);
+      } else {
+        // Message only: RPC errors can embed the endpoint URL (with API key).
+        console.log(
+          `⚠️ Direct read failed for collection ${chunk[j].address.slice(
+            0,
+            10
+          )}, will use fallback: ${outcome.reason?.message ?? outcome.reason}`
+        );
+      }
+    });
+  }
+
+  console.log(
+    `✅ Direct read of ${results.size}/${collections.length} collections (${
+      results.size * CALLS_PER_COLLECTION
+    } calls): ${fmt(performance.now() - start)}`
+  );
+
+  return results;
+}
+
+async function readCollection(
+  ctx: Context,
+  blockHeader: Block,
+  address: string
+): Promise<CollectionData> {
+  const contract = new CollectionV2Contract(ctx, blockHeader, address);
+  const [
+    name,
+    symbol,
+    owner,
+    creator,
+    isCompleted,
+    isApproved,
+    isEditable,
+    baseURI,
+  ] = await Promise.all([
+    contract.name(),
+    contract.symbol(),
+    contract.owner(),
+    contract.creator(),
+    contract.isCompleted(),
+    contract.isApproved(),
+    contract.isEditable(),
+    contract.baseURI(),
+  ]);
+
+  return {
+    address: address.toLowerCase(),
+    name,
+    symbol,
+    owner: owner.toLowerCase(),
+    creator: creator.toLowerCase(),
+    isCompleted,
+    isApproved,
+    isEditable,
+    baseURI,
+    chainId: CHAIN_ID,
+  };
+}

--- a/src/polygon/utils/collectionMulticall.ts
+++ b/src/polygon/utils/collectionMulticall.ts
@@ -21,8 +21,10 @@ const MULTICALL_CONTRACT = "0xcA11bde05977b3631167028862bE2a173976CA11";
 export const POLYGON_MULTICALL_CREATION_BLOCK = 25770160;
 
 // How many collections the direct path reads concurrently. Each issues CALLS_PER_COLLECTION
-// eth_calls, so this bounds the promise fan-out; the RPC client's own capacity/rateLimit is
-// what actually paces the requests.
+// eth_calls, so 25 puts ~200 in flight against the RPC client's capacity of 100: enough queued
+// to keep the client busy while the first wave drains, without materializing a promise per
+// collection on a batch that creates hundreds. The client's capacity/rateLimit is what actually
+// paces the requests — this only bounds the fan-out.
 const DIRECT_FETCH_CONCURRENCY = 25;
 
 const fmt = (ms: number) =>

--- a/src/polygon/utils/collectionMulticall.ts
+++ b/src/polygon/utils/collectionMulticall.ts
@@ -1,9 +1,9 @@
-import { ChainId } from "@dcl/schemas";
 import { Multicall, AggregateTuple } from "../../abi/multicall";
 import {
   Contract as CollectionV2Contract,
   functions as CollectionV2Functions,
 } from "../abi/CollectionV2";
+import { POLYGON_CHAIN_ID } from "../../config";
 import type { Context, Block } from "../processor";
 
 // Number of contract calls issued per collection. Keep in sync with the calls pushed below,
@@ -13,8 +13,6 @@ import type { Context, Block } from "../processor";
 // processor is always POLYGON_CHAIN_ID, so calling it spends one RPC per collection to learn a
 // constant we already have.
 const CALLS_PER_COLLECTION = 8;
-
-const CHAIN_ID = BigInt(process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET);
 
 const MULTICALL_CONTRACT = "0xcA11bde05977b3631167028862bE2a173976CA11";
 // Multicall3 was deployed on Polygon at block 25770160. Everything BELOW it — the first ~28% of
@@ -121,7 +119,7 @@ export async function fetchCollectionDataMulticall(
         isApproved: rawResults[baseIndex + 5].value as boolean,
         isEditable: rawResults[baseIndex + 6].value as boolean,
         baseURI: rawResults[baseIndex + 7].value as string,
-        chainId: CHAIN_ID,
+        chainId: POLYGON_CHAIN_ID,
       });
     }
   } catch (e: any) {
@@ -175,12 +173,13 @@ export async function fetchCollectionDataDirect(
       if (outcome.status === "fulfilled") {
         results.set(outcome.value.address, outcome.value);
       } else {
-        // Message only: RPC errors can embed the endpoint URL (with API key).
+        // Message only, and never the rejection value itself: RPC errors can embed the
+        // endpoint URL (with API key), and a library is free to reject with a bare string.
         console.log(
           `⚠️ Direct read failed for collection ${chunk[j].address.slice(
             0,
             10
-          )}, will use fallback: ${outcome.reason?.message ?? outcome.reason}`
+          )}, will use fallback: ${outcome.reason?.message ?? "unknown error"}`
         );
       }
     });
@@ -231,6 +230,6 @@ async function readCollection(
     isApproved,
     isEditable,
     baseURI,
-    chainId: CHAIN_ID,
+    chainId: POLYGON_CHAIN_ID,
   };
 }


### PR DESCRIPTION
A from-scratch Polygon reindex is bound by `eth_call`, not by Postgres. From a representative batch in the current prod reindex:

```
📍 Breakdown: accumulation=5.6s, RPC=5.0s, handleCollection=50.1s, processEvents=345ms
⚠️  WARNING SLOW: DB Queries: 2.8s | Event Loop: 58.3s | RPC: 5.1s | DB Upserts: 8.7s | Total: 65.0s
```

`handleCollection` is 50.1s of a 65.0s batch, and runs 37-77% of wall clock across the slow batches. Neither side is saturated: the DB writer sits at 28-50% of 4 vCPU with ~1.0 average active sessions, 0.05 non-CPU wait, 60 µs write latency and 0.5 ms commit latency; the processor's own task is at 3-18% of 2 vCPU. The time is spent waiting.

Multicall3 was deployed on Polygon at block `25_770_160`. Everything below it — the first ~28% of the chain, and most of the collections ever created — has no multicall, so `fetchCollectionDataMulticall` returns nothing and each collection is read with individual `eth_call`s. Over 90 minutes of the current reindex: 334 batches on the fallback, 0 successful multicalls.

```
⚠️ Block 23010932 is before multicall creation, falling back to individual calls
⚠️ handleCollectionCreation RPC fallback for 0x156a026b: 1.1s
⚠️ handleCollectionCreation RPC fallback for 0x656920c5: 1.2s
```

Three things compound: the RPC client is capped at 10 req/s, so 9 calls per collection is ~0.9s each (which is what the fallback logs); those reads ran one collection after another inside the handler loop; and one of the calls was `getChainId()`, which returns `block.chainid` — always `POLYGON_CHAIN_ID` here.

## Changes

- `capacity`/`rateLimit` 10 → 100 on the Polygon and Ethereum RPC clients. Measured against the endpoint we actually use, 100 concurrent `eth_call`s return in ~356 ms with zero errors, so the cap was ~28x below what it serves.
- New `fetchCollectionDataDirect` reads the collections the multicall could not cover **concurrently** (fan-out bounded at 25), before the handler loop. That loop has to stay sequential because `handleCollectionCreation` read-modify-writes shared `storedData` across awaits — but that constraint is on the state mutation, not on the reads. The loop is now pure in-memory.
- Dropped `getChainId()` from both the multicall and the fallback; `chainId` comes from config. `CALLS_PER_COLLECTION` 9 → 8.

Behaviour is unchanged:

- The new prefetch reads each collection **at its own creation block**, exactly as the per-collection fallback did — not at the batch's last block like the multicall path. `owner` / `isCompleted` / `isApproved` / `isEditable` are mutable, so the two are not interchangeable, and this keeps the stricter one.
- A collection whose reads fail is omitted and still falls through to the existing per-collection fallback, which is kept.
- The `.toLowerCase()` on `owner`/`creator` in the new path is a no-op: `@subsquid/evm-codec` decodes addresses as `'0x' + bigint.toString(16)`, already lowercase. The multicall and direct paths therefore produce identical values.

This is deliberately **not** for the reindex currently in flight: a new image means a new commit hash, a new schema, and a reindex from zero. That run is already closing on the `25_770_160` boundary, past which the multicall takes over anyway.

## Test plan

- [x] `tsc --noEmit` clean
- [x] No schema or migration changes
- [ ] Next from-scratch reindex: `handleCollection` should drop out of the top of the batch breakdown