### PR TITLE
fix: bulk mode dropped two indices the processor itself reads

### DIFF
--- a/src/common/utils/indexManager.ts
+++ b/src/common/utils/indexManager.ts
@@ -10,10 +10,14 @@
  * manages only the tables it owns. Tables that both processors write (nft, order,
  * sale, bid, transfer, metadata, account, wearable) are managed by the Polygon
  * processor, which is by far the dominant writer of those rows; the ETH processor
- * only manages its exclusive tables (parcel, estate, ens, data). The query-layer
- * indices are not needed by either processor's write path (which looks entities up
- * by primary key), so dropping the shared ones during Polygon's backfill does not
- * slow ETH's backfill.
+ * only manages its exclusive tables (parcel, estate, ens, data).
+ *
+ * MOST query-layer indices are not needed by either processor's own path, which looks entities up
+ * by primary key — so dropping the shared ones during Polygon's backfill does not slow ETH's.
+ * Two are the exception: getStoredData resolves orders by `nft_id` and items by `collection_id`,
+ * neither of which is a primary key. Those carry `keepDuringBulkLoad` and are never dropped.
+ * Assuming the write path was PK-only cost a 4.6x slowdown on a prod backfill before it was
+ * caught, so verify against the actual store queries before adding an index here.
  *
  * All DDL runs on an independent connection, outside the batch transaction (see
  * withIndexConnection), so each CREATE/DROP INDEX autocommits on its own instead
@@ -38,7 +42,16 @@ import { createSlackComponent, ISlackComponent } from "./slack";
 // Log prefix for easy filtering in Grafana
 const LOG_PREFIX = "[IndexMgr]";
 
-export type ManagedIndex = { name: string; create: string };
+/**
+ * `keepDuringBulkLoad` marks an index the PROCESSOR's own read path needs, not just the query
+ * layer. Bulk mode leaves those in place: dropping them makes the backfill slower, because every
+ * batch then seq-scans the table they serve. See the two flagged below.
+ */
+export type ManagedIndex = {
+  name: string;
+  create: string;
+  keepDuringBulkLoad?: boolean;
+};
 export type IndexGroup = Record<string, ManagedIndex[]>;
 
 // Secondary indices owned by the Polygon processor (plus the shared marketplace
@@ -66,7 +79,10 @@ export const POLYGON_INDICES: IndexGroup = {
   order: [
     { name: "IDX_2485593ed8c9972197aeaf7da6", create: `CREATE INDEX "IDX_2485593ed8c9972197aeaf7da6" ON "order" ("expires_at_normalized")` },
     { name: "IDX_d01158fe15b1ead5c26fd7f4e9", create: `CREATE INDEX "IDX_d01158fe15b1ead5c26fd7f4e9" ON "order" ("item_id")` },
-    { name: "IDX_f5047ff046d513a3598c1a2931", create: `CREATE INDEX "IDX_f5047ff046d513a3598c1a2931" ON "order" ("nft_id")` },
+    // KEPT during bulk load: getStoredData does `findBy(Order, { nft: In([...nftIds]) })` once per
+    // batch. Without this index that is a seq scan of `order` per batch, and it gets worse as the
+    // table grows — measured at 4.6x slower overall on a prod backfill.
+    { name: "IDX_f5047ff046d513a3598c1a2931", create: `CREATE INDEX "IDX_f5047ff046d513a3598c1a2931" ON "order" ("nft_id")`, keepDuringBulkLoad: true },
   ],
   sale: [
     { name: "IDX_8ac00a610840894296c6f32fd2", create: `CREATE INDEX "IDX_8ac00a610840894296c6f32fd2" ON "sale" ("timestamp")` },
@@ -75,7 +91,9 @@ export const POLYGON_INDICES: IndexGroup = {
     { name: "IDX_8524438f82167bcb795bcb8663", create: `CREATE INDEX "IDX_8524438f82167bcb795bcb8663" ON "sale" ("nft_id")` },
   ],
   item: [
-    { name: "IDX_9ddbd0267ddb9c59621775f94e", create: `CREATE INDEX "IDX_9ddbd0267ddb9c59621775f94e" ON "item" ("collection_id", "blockchain_id")` },
+    // KEPT during bulk load: getStoredData looks items up by `collection` (not by PK) once per
+    // batch, for the same reason as order.nft_id above.
+    { name: "IDX_9ddbd0267ddb9c59621775f94e", create: `CREATE INDEX "IDX_9ddbd0267ddb9c59621775f94e" ON "item" ("collection_id", "blockchain_id")`, keepDuringBulkLoad: true },
     { name: "IDX_6d5bb320c601281cd3a213979e", create: `CREATE INDEX "IDX_6d5bb320c601281cd3a213979e" ON "item" ("metadata_id")` },
   ],
   bid: [
@@ -256,7 +274,8 @@ async function getIndicesStatus(
  * independent connection so it autocommits outside the batch transaction.
  */
 export async function dropIndicesForBulkLoad(store: Store, group: IndexGroup): Promise<void> {
-  const indices = flattenIndices(group);
+  // Anything the processor's own read path needs stays — see keepDuringBulkLoad.
+  const indices = flattenIndices(group).filter((idx) => !idx.keepDuringBulkLoad);
   await withIndexConnection(store, async (runner) => {
     const statusBefore = await getIndicesStatus(runner, indices);
 
@@ -367,9 +386,14 @@ export async function recreateIndices(store: Store, group: IndexGroup): Promise<
       );
     }
 
+    // Throw rather than return: per-index failures are caught inside the loop above, so without
+    // this the caller sees a clean return, latches "indices recreated" and never retries — leaving
+    // production permanently missing an index with nothing but a Slack message to say so.
     const statusAfter = await getIndicesStatus(runner, indices);
     if (statusAfter.missingCount > 0) {
-      console.log(`${LOG_PREFIX} ⚠️ Still missing ${statusAfter.missingCount} indices`);
+      throw new Error(
+        `${statusAfter.missingCount} of ${statusAfter.total} indices are still missing after the recreate pass`
+      );
     }
   });
 }

--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -92,6 +92,11 @@ const BULK_INDEX_MODE = process.env.BULK_INDEX_MODE === "true";
 let bulkModeInitialized = false;
 let indicesRecreated = false;
 let indicesNeedRecreation = false;
+// See the same pair in polygon/main.ts: recreateIndices now throws while indices are missing, so
+// the head handler retries — bounded, because an index that can never be built would otherwise
+// re-attempt on every batch forever.
+let indexRecreateAttempts = 0;
+const MAX_INDEX_RECREATE_ATTEMPTS = 5;
 const ETH_INITIAL_BLOCK = getBlockRange(Network.ETHEREUM).from;
 
 const schemaName = process.env.DB_SCHEMA;
@@ -187,13 +192,26 @@ run(dataSource, db, async (simpleCtx) => {
     // CREATE INDEX (SHARE lock) on an independent connection, which would deadlock
     // against ROW EXCLUSIVE locks the batch transaction takes once it starts writing.
     // recreateIndices is a no-op when nothing is missing; on error we retry next batch.
-    if (BULK_INDEX_MODE && !indicesRecreated && ctx.isHead) {
+    if (
+      BULK_INDEX_MODE &&
+      !indicesRecreated &&
+      ctx.isHead &&
+      indexRecreateAttempts < MAX_INDEX_RECREATE_ATTEMPTS
+    ) {
+      indexRecreateAttempts++;
       console.log(`[IndexMgr] Reached chain head (eth) - recreating indices`);
       try {
         await recreateIndices(ctx.store, ETH_INDICES);
         indicesRecreated = true;
       } catch (e: any) {
-        console.log(`[IndexMgr] Error recreating indices (eth): ${e.message}`);
+        console.log(
+          `[IndexMgr] Error recreating indices (eth) (attempt ${indexRecreateAttempts}/${MAX_INDEX_RECREATE_ATTEMPTS}): ${e.message}`
+        );
+        if (indexRecreateAttempts >= MAX_INDEX_RECREATE_ATTEMPTS) {
+          console.log(
+            `[IndexMgr] Giving up. The query layer is serving WITHOUT some indices — recreate them by hand.`
+          );
+        }
       }
     }
 

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -180,6 +180,11 @@ const BULK_INDEX_MODE = process.env.BULK_INDEX_MODE === "true";
 let bulkModeInitialized = false;
 let indicesRecreated = false;
 let indicesNeedRecreation = false; // Will be set on startup check
+// recreateIndices throws while anything is still missing, so the head handler retries it. Bounded
+// because at head a batch runs every few seconds: an index that can never be built (a UNIQUE one
+// with duplicate rows, say) would otherwise re-attempt forever.
+let indexRecreateAttempts = 0;
+const MAX_INDEX_RECREATE_ATTEMPTS = 5;
 
 // Get the chainId and calculate the lowest initial block for this network
 const chainId = +(process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET);
@@ -441,13 +446,26 @@ run(dataSource, db, async (simpleCtx) => {
     // returns, and the handler is awaiting the CREATE INDEX. Running it here, before
     // any table access, keeps the connections contention-free. recreateIndices is a
     // no-op when nothing is missing; on error we retry next batch.
-    if (BULK_INDEX_MODE && !indicesRecreated && ctx.isHead) {
+    if (
+      BULK_INDEX_MODE &&
+      !indicesRecreated &&
+      ctx.isHead &&
+      indexRecreateAttempts < MAX_INDEX_RECREATE_ATTEMPTS
+    ) {
+      indexRecreateAttempts++;
       console.log(`[IndexMgr] Reached chain head - recreating indices`);
       try {
         await recreateIndices(ctx.store, POLYGON_INDICES);
         indicesRecreated = true;
       } catch (e: any) {
-        console.log(`[IndexMgr] Error recreating indices: ${e.message}`);
+        console.log(
+          `[IndexMgr] Error recreating indices (attempt ${indexRecreateAttempts}/${MAX_INDEX_RECREATE_ATTEMPTS}): ${e.message}`
+        );
+        if (indexRecreateAttempts >= MAX_INDEX_RECREATE_ATTEMPTS) {
+          console.log(
+            `[IndexMgr] Giving up. The query layer is serving WITHOUT some indices — recreate them by hand.`
+          );
+        }
       }
     }
 


### PR DESCRIPTION
`BULK_INDEX_MODE` drops the query-layer indices during a backfill and recreates them at head. The premise, stated in the file header, was that no index it drops is on the processor's own path, "which looks entities up by primary key".

That is true of 50 of the 52 managed indices. It is false of two, and `getStoredData` hits both once per batch:

```ts
findBy(Order, { nft: In([...nftIds]), network: POLYGON })          // needs order(nft_id)
find(Item, { where: [{ collection: In(collectionIds) }, ...] })    // needs item(collection_id, blockchain_id)
```

Neither is a primary key. With those two dropped, each batch seq-scans `order` and `item`, and it degrades as the tables grow. Measured on a prod backfill: **4.6x slower** — 32 min against 7 min to reach the same block — with batches shrinking from ~35,000 blocks to ~300 as the processor's adaptive sizing fought the rising per-batch cost. The mode meant to speed the backfill up was the thing slowing it down.

## Changes

- `ManagedIndex` gets `keepDuringBulkLoad`. `dropIndicesForBulkLoad` skips anything carrying it; `recreateIndices` still verifies it exists, so a missing one is created rather than assumed.
- Flagged `order(nft_id)` and `item(collection_id, blockchain_id)`, each with the store query that needs it named in a comment.
- Corrected the file header, which asserted the false premise that led here.
- `recreateIndices` now **throws** while indices are still missing. Per-index failures are caught inside its loop, so it used to return cleanly having created nothing; the caller latched `indicesRecreated = true` and never retried, leaving production permanently missing an index with only a Slack message to say so. The caller's comment already claimed "on error we retry next batch" — now that is true.
- Bounded that retry at 5 attempts in both processors. At head a batch runs every few seconds, so an index that can never be built (a UNIQUE one with duplicate rows, say) would otherwise re-attempt forever. On giving up it says plainly that the query layer is serving without indices.

## Scope

`BULK_INDEX_MODE` is opt-in and currently set only on `marketplace-squid-server-b`, the staging slot. Nothing here changes behaviour when it is off.

The reindex running right now is unaffected: both indices were recreated by hand on its schema mid-run, which is what stopped the bleeding and is what this makes unnecessary next time.

## Test plan

- [x] `tsc --noEmit` clean
- [x] No schema or migration changes
- [ ] Next bulk-mode reindex: `[IndexMgr] Drop complete` should report 50 dropped, not 52
- [ ] Confirm `order(nft_id)` and `item(collection_id, blockchain_id)` survive in `pg_indexes` during the backfill