### PR TITLE
fix: stop reading the marketplace fee config on every trade

### DIFF
--- a/src/polygon/handlers/marketplace.ts
+++ b/src/polygon/handlers/marketplace.ts
@@ -26,7 +26,11 @@ import { trackSale } from "../modules/analytics";
 import { PolygonInMemoryState, PolygonStoredData } from "../types";
 import { buildCountFromOrder } from "../../common/modules/count";
 import { getAddresses } from "../../common/utils/addresses";
-import { MarketplaceContractData, MarketplaceV2ContractData } from "../state";
+import {
+  MarketplaceContractData,
+  MarketplaceV2ContractData,
+  getMarketplaceV3ContractData,
+} from "../state";
 import { Context } from "../processor";
 import { TradedEventArgs } from "../abi/DecentralandMarketplacePolygon";
 import { handleIssue } from "./collection";
@@ -254,14 +258,11 @@ export async function handleTraded(
   }
   const { assetType, collectionAddress, tokenId, buyer, price, seller } =
     tradeData;
-  const marketplaceV3Contract = new MarketplaceV3ABI.Contract(
-    ctx,
-    block.header,
-    addresses.MarketplaceV3
-  );
-  const feesCollector = await marketplaceV3Contract.feeCollector();
-  const feeRate = await marketplaceV3Contract.feeRate();
-  const royaltiesRate = await marketplaceV3Contract.royaltiesRate();
+  // Read once and kept current from the contract's own *Updated events — see
+  // getMarketplaceV3ContractData. This used to be three sequential eth_calls PER Traded event.
+  const { feeCollector, feeRate, royaltiesRate } =
+    await getMarketplaceV3ContractData(ctx, block.header);
+  const feesCollector = feeCollector;
 
   // NFT
   if (Number(assetType) === TradeAssetType.ERC721) {

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -75,6 +75,9 @@ import {
   getStoreContractData,
   setBidOwnerCutPerMillion,
   setMarketplaceOwnerCutPerMillion,
+  setMarketplaceV3FeeCollector,
+  setMarketplaceV3FeeRate,
+  setMarketplaceV3RoyaltiesRate,
   setStoreFee,
   setStoreFeeOwner,
 } from "./state";
@@ -958,6 +961,32 @@ run(dataSource, db, async (simpleCtx) => {
               marketplaceV2ContractData: cachedMarketplaceV2Data,
               bidV2ContractData: cachedBidV2Data,
             });
+            break;
+          }
+          // Keep the cached V3 fee configuration current. Same shape as the V1/V2 cases below,
+          // and it inherits their one caveat: these are applied while events are accumulated,
+          // whereas Traded is handled later in the batch. So a fee change and trades in the SAME
+          // batch are applied out of order — trades before the change would see the new value.
+          // At head a batch is seconds wide so this cannot happen; during a backfill a batch can
+          // span ~1M blocks, and it would only matter around the handful of blocks where fees
+          // actually changed. Resolving per-trade needs the change recorded with its block and
+          // applied as-of, which is a bigger change than this one.
+          case MarketplaceV3ABI.events.FeeCollectorUpdated.topic: {
+            setMarketplaceV3FeeCollector(
+              MarketplaceV3ABI.events.FeeCollectorUpdated.decode(log)._feeCollector
+            );
+            break;
+          }
+          case MarketplaceV3ABI.events.FeeRateUpdated.topic: {
+            setMarketplaceV3FeeRate(
+              MarketplaceV3ABI.events.FeeRateUpdated.decode(log)._feeRate
+            );
+            break;
+          }
+          case MarketplaceV3ABI.events.RoyaltiesRateUpdated.topic: {
+            setMarketplaceV3RoyaltiesRate(
+              MarketplaceV3ABI.events.RoyaltiesRateUpdated.decode(log)._royaltiesRate
+            );
             break;
           }
           case MarketplaceV2ABI.events.ChangedFeesCollectorCutPerMillion.topic:

--- a/src/polygon/processor.ts
+++ b/src/polygon/processor.ts
@@ -187,6 +187,19 @@ export const dataSource = new DataSourceBuilder()
     },
     include: { transaction: true },
   })
+  // Fee configuration of the V3 marketplace. handleTraded needs these values on every trade and
+  // used to fetch them over RPC each time; ingesting the changes instead keeps the cached copy
+  // current for free. Only the MarketplaceV3 address: that is the contract handleTraded reads.
+  .addLog({
+    where: {
+      address: [addresses.MarketplaceV3],
+      topic0: [
+        MarketplaceV3.events.FeeCollectorUpdated.topic,
+        MarketplaceV3.events.FeeRateUpdated.topic,
+        MarketplaceV3.events.RoyaltiesRateUpdated.topic,
+      ],
+    },
+  })
   .addLog({
     where: {
       address: addresses.CreditsManager,

--- a/src/polygon/state.ts
+++ b/src/polygon/state.ts
@@ -4,6 +4,7 @@ import { Sale } from "../model";
 import { getAddresses } from "../common/utils/addresses";
 import { Contract as MarketplaceContract } from "./abi/Marketplace";
 import { Contract as MarketplaceV2Contract } from "./abi/MarketplaceV2";
+import { Contract as MarketplaceV3Contract } from "./abi/DecentralandMarketplacePolygon";
 import { Contract as CollectionStoreContract } from "./abi/CollectionStore";
 import { Contract as ERC721BidV2Contract } from "./abi/ERC721BidV2";
 import { Block, Context } from "./processor";
@@ -81,6 +82,71 @@ export let bidV2ContractData: BidV2ContractData = {
 export let storeContractData: StoreContractData = {
   fee: undefined,
   feeOwner: undefined,
+};
+
+export type MarketplaceV3ContractData = {
+  feeCollector: string | undefined;
+  feeRate: bigint | undefined;
+  royaltiesRate: bigint | undefined;
+};
+
+export let marketplaceV3ContractData: MarketplaceV3ContractData = {
+  feeCollector: undefined,
+  feeRate: undefined,
+  royaltiesRate: undefined,
+};
+
+/**
+ * Fee configuration of the V3 marketplace, read from the chain ONCE and kept current from the
+ * contract's own FeeCollectorUpdated / FeeRateUpdated / RoyaltiesRateUpdated events.
+ *
+ * handleTraded used to read all three per Traded event — three sequential eth_calls for values
+ * that change roughly never. Against the RPC client's rate limit that was ~0.3s per trade, and
+ * because the calls were not attributed to any rpcTime bucket it showed up as unexplained
+ * "event loop" time: 548s of a 671s batch on a prod backfill through 2025 blocks.
+ *
+ * Unlike the other getters here there is no start-block guard, and none is needed: this is only
+ * ever called from handleTraded, and a Traded event cannot exist before the contract does.
+ *
+ * Deliberately NOT wrapped in try/catch, unlike its siblings. These values land in the Sale's
+ * money columns (feesCollectorCut, royaltiesCut), so a read failure must fail the batch and be
+ * retried — swallowing it would either skip the sale or record it with empty fees.
+ */
+export const getMarketplaceV3ContractData = async (
+  ctx: Context,
+  block: Block
+): Promise<{ feeCollector: string; feeRate: bigint; royaltiesRate: bigint }> => {
+  let { feeCollector, feeRate, royaltiesRate } = marketplaceV3ContractData;
+  if (
+    feeCollector === undefined ||
+    feeRate === undefined ||
+    royaltiesRate === undefined
+  ) {
+    console.log("INFO: Fetching marketplace v3 contract data for first time");
+    const addresses = getAddresses(Network.MATIC);
+    const c = new MarketplaceV3Contract(ctx, block, addresses.MarketplaceV3);
+    [feeCollector, feeRate, royaltiesRate] = await Promise.all([
+      c.feeCollector(),
+      c.feeRate(),
+      c.royaltiesRate(),
+    ]);
+    marketplaceV3ContractData.feeCollector = feeCollector;
+    marketplaceV3ContractData.feeRate = feeRate;
+    marketplaceV3ContractData.royaltiesRate = royaltiesRate;
+  }
+  return { feeCollector, feeRate, royaltiesRate };
+};
+
+export const setMarketplaceV3FeeCollector = (value: string) => {
+  marketplaceV3ContractData.feeCollector = value;
+};
+
+export const setMarketplaceV3FeeRate = (value: bigint) => {
+  marketplaceV3ContractData.feeRate = value;
+};
+
+export const setMarketplaceV3RoyaltiesRate = (value: bigint) => {
+  marketplaceV3ContractData.royaltiesRate = value;
 };
 
 // CollectionStore contract creation blocks


### PR DESCRIPTION
`handleTraded` opened a contract wrapper and issued three sequential `eth_call`s for every single `Traded` event:

```ts
const feesCollector  = await marketplaceV3Contract.feeCollector();
const feeRate        = await marketplaceV3Contract.feeRate();
const royaltiesRate  = await marketplaceV3Contract.royaltiesRate();
```

Those are marketplace configuration. They change by governance action, roughly never.

## What it cost

Against the RPC client's rate limit that is ~0.3s per trade, and because the calls were not attributed to any `rpcTime` bucket they were invisible in the batch metrics — they surfaced only as unexplained "event loop" time. From a prod backfill through 2025 blocks:

```
📍 Breakdown: accumulation=105.0s, RPC=104.6s, handleCollection=0ms, processEvents=548.2s
⚠️  WARNING SLOW: DB Queries: 5.7s | Event Loop: 757.7s | RPC: 104.6s | DB Upserts: 11.7s | Total: 671.6s
```

`processEvents` is **548s of a 671s batch**, with no RPC attributed to it. That batch spanned ~764k blocks ≈ 17.7 days of chain around Aug 2025; the live index records 1,912 sales that month (~1,128 per 17.7 days) plus item mints, which also go through `Traded`. On the order of 1,500-2,500 trades × ~0.3s = 450-750s. The 548s is accounted for.

This also explains why the term appeared only late in a backfill: MarketplaceV3 is recent, so early blocks carry almost no `Traded` events.

It is not only a backfill problem — every sale in production costs three synchronous `eth_call`s today, which slows head-following and burns RPC quota.

## Changes

- `getMarketplaceV3ContractData` in `state.ts`: reads the three values once and caches them, following the existing `getMarketplaceV2ContractData` / `getStoreContractData` pattern.
- The contract's own `FeeCollectorUpdated` / `FeeRateUpdated` / `RoyaltiesRateUpdated` events are now ingested and keep the cache current, so it does not go stale.
- `handleTraded` reads the cache.

Deliberately **not** wrapped in try/catch, unlike its siblings in that file: these values land in the Sale's money columns (`feesCollectorCut`, `royaltiesCut`), so a read failure must fail the batch and be retried rather than skipping the sale or recording it with empty fees. The three first-read calls are now issued concurrently instead of sequentially.

No start-block guard is needed — the fetch hangs off the first `Traded` event, and a `Traded` cannot exist before the contract does.

## Known limitation, stated rather than hidden

The `*Updated` events are applied while events are accumulated, whereas `Traded` is handled later in the batch. A fee change and trades in the **same batch** are therefore applied out of order: trades before the change would see the new value. This is the same property the existing V1/V2 cases have.

At head a batch is seconds wide, so it cannot happen. During a backfill a batch can span ~1M blocks, so it could — but only around the handful of blocks where fees actually changed. Making it exact requires recording each change with its block and resolving as-of per trade; that is a larger change and I did not want to bundle it here. Say the word and I will do it.

## Unrelated thing I noticed and did NOT change

`handleTraded` reads from `addresses.MarketplaceV3` unconditionally, including for trades on `MarketplaceV3_V2`. If the two contracts ever carry different fee configuration, V3_V2 sales are recorded with V3's. Left exactly as-is here so this stays a pure performance change; worth its own look.

## Test plan

- [x] `tsc --noEmit` clean
- [x] No schema or migration changes
- [ ] Next backfill: `processEvents` should drop out of the batch breakdown, and `INFO: Fetching marketplace v3 contract data for first time` should appear exactly once