### PR TITLE
fix: collections retriever scanned mainnet with testnet factory addresses

### DIFF
--- a/src/polygon/tools/collectionsRetriever.ts
+++ b/src/polygon/tools/collectionsRetriever.ts
@@ -20,12 +20,29 @@ const fromsV3: Record<string, any> = {
 };
 
 const logger = createLogger("sqd:collections-retriever");
-const addresses = getAddresses(Network.MATIC);
-const chainId = process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET;
 
-const fileName = `collections_${
-  +chainId === ChainId.MATIC_MAINNET ? "mainnet" : "amoy"
-}.json`;
+// Resolve the chain ONCE and write it back to the environment BEFORE anything reads an address.
+//
+// `getAddresses` re-reads POLYGON_CHAIN_ID itself and compares it as a STRING, so anything that is not
+// exactly "137" — including unset — resolves to Amoy. This tool defaults the same variable to mainnet.
+// Left to disagree, a run picks the mainnet dataset, the mainnet start blocks and the mainnet filename,
+// then filters all of it for the AMOY factory addresses: it matches nothing, runs happily to head, and
+// writes a snapshot whose height advanced by millions of blocks while its address list did not grow.
+//
+// Committing that is worse than leaving the snapshot stale. The processor address-filters collection
+// logs up to the recorded height, so every collection created inside the range the file CLAIMS to have
+// scanned would become invisible to it.
+const chainId = process.env.POLYGON_CHAIN_ID || ChainId.MATIC_MAINNET.toString();
+process.env.POLYGON_CHAIN_ID = chainId;
+
+const addresses = getAddresses(Network.MATIC);
+
+// One derived flag for every network-dependent choice below. They used to be decided independently —
+// one with `+chainId ===`, another with a loose `==` against a numeric enum — which is how the file
+// name, the dataset and the addresses were able to disagree about which chain this run was for.
+const isMainnet = +chainId === ChainId.MATIC_MAINNET;
+
+const fileName = `collections_${isMainnet ? "mainnet" : "amoy"}.json`;
 
 // SQD Network Portal, the same dataset the processors read (see polygon/processor.ts). This used to
 // point at `v2.archive.subsquid.io`, which STARTED REQUIRING AN API KEY on 19 May 2026 — after which
@@ -36,7 +53,7 @@ const fileName = `collections_${
 //
 // The Portal needs no key, so this can be run by anyone (and by CI) without a secret.
 const PORTAL_URL = `https://portal.sqd.dev/datasets/polygon-${
-  chainId == ChainId.MATIC_MAINNET ? "mainnet" : "amoy-testnet"
+  isMainnet ? "mainnet" : "amoy-testnet"
 }`;
 
 const dataSource = new DataSourceBuilder()
@@ -73,6 +90,17 @@ type Metadata = {
 let isInit = false;
 let isReady = false;
 
+// Where this run resumed from, and how big the address list was there. Both only to sanity-check the
+// result at head — see the guard in the batch handler.
+let startHeight: number | undefined;
+let startCount = 0;
+let lastHeight = 0;
+
+// A run that scans further than this and finds NOTHING is reporting a broken filter, not a quiet chain.
+// Sized well above a weekly run (~300k blocks on Polygon) so an ordinary refresh can never trip it, and
+// well below the multi-million-block backfills where this actually went wrong.
+const SUSPICIOUS_EMPTY_SCAN_BLOCKS = 1_000_000;
+
 let db = new Database({
   tables: {},
   dest: new LocalDest("./assets"),
@@ -86,6 +114,8 @@ let db = new Database({
 
         if (!isInit) {
           collections = addresses;
+          startHeight = height;
+          startCount = addresses.length;
           isInit = true;
         }
 
@@ -108,8 +138,29 @@ let db = new Database({
 
 run(dataSource, db, async (ctx) => {
   ctx.store.setForceFlush(true);
-  if (isReady) process.exit();
+  if (isReady) {
+    const scanned = lastHeight - (startHeight ?? lastHeight);
+    const found = collections.length - startCount;
+    // Reaching head proves the run finished, NOT that it worked. Scanning millions of blocks of a chain
+    // this size without seeing a single ProxyCreated means the subscription matched nothing — a wrong
+    // network's factory addresses, a changed topic, the wrong dataset. Exit non-zero so CI stops before
+    // the commit step, and say plainly that the file on disk is now wrong.
+    if (found === 0 && scanned > SUSPICIOUS_EMPTY_SCAN_BLOCKS) {
+      logger.fatal(
+        `Scanned ${scanned} blocks up to ${lastHeight} and found NO collections. ` +
+          `Filtering on CollectionFactory=${addresses.CollectionFactory} ` +
+          `CollectionFactoryV3=${addresses.CollectionFactoryV3} (POLYGON_CHAIN_ID=${chainId}). ` +
+          `${fileName} now claims that height with an unchanged address list — DISCARD it, do not commit.`
+      );
+      process.exit(1);
+    }
+    logger.info(`done: +${found} collections over ${scanned} blocks, head ${lastHeight}`);
+    process.exit();
+  }
   if (ctx.isHead) isReady = true;
+  if (ctx.blocks.length > 0) {
+    lastHeight = ctx.blocks[ctx.blocks.length - 1].header.height;
+  }
 
   for (let c of ctx.blocks) {
     for (let i of c.logs) {


### PR DESCRIPTION
## The bug

`getAddresses` picks its address file by comparing `POLYGON_CHAIN_ID` **as a string**, so anything that is not exactly `"137"` — including **unset** — resolves to Amoy:

```ts
chainId === ChainId.MATIC_MAINNET.toString() ? "mainnet" : "amoy"
```

The retriever defaults the same variable the other way (`|| ChainId.MATIC_MAINNET`). So a run with no `POLYGON_CHAIN_ID` in the environment used:

| | resolved to |
|---|---|
| dataset | polygon-**mainnet** |
| start blocks | **mainnet** (15202000 / 28121692) |
| output file | `collections_**mainnet**.json` |
| factory addresses | **AMOY** (`0x2A72Ec42…`, `0x802de0c5…`) |

It scanned mainnet for testnet contracts, matched nothing, ran happily to head and exited 0.

## Why this was worse than a slow snapshot

The run still advances the recorded height. A manual run took 2h44m, reached head, and wrote a file claiming ~11M more blocks of coverage with the address list unchanged at 5,772 — while the live index holds 5,944.

The processor address-filters collection logs **up to the recorded height**. Committing that file would have made every collection created inside the range it claims to have scanned invisible to the filtered subscription — a correctness bug, not a performance one. The output was discarded.

## Reproduction, and proof of the fix

`0x479b656ea58fce1eb01196abc909652424af2d28` (created 2026-07-01, block 89442895) is indexed live but absent from the snapshot. Its creation receipt carries the expected log, so nothing about the contract set had changed:

```
addr=0x3195e88ae10704b359764cb38e429d24f1c2f781   (CollectionFactoryV3)
topic0=0xcfaab0d6675a72a93c114f48dd85add1076be0c88545968759ef034da7ad146f   (ProxyCreated)
```

Resuming from block 89442800 and running past it:

- **before** — scanned through 89497563, captured 0
- **after** — captured `0x479b656ea58fce1eb01196abc909652424af2d28`

## Changes

- Resolve the chain **once**, write it back to `process.env.POLYGON_CHAIN_ID` before `getAddresses` reads it, so the addresses cannot disagree with the dataset and the file name.
- Derive dataset, file name and start blocks from a single `isMainnet`. They were each deciding independently, one with `+chainId ===` and another with a loose `==` against a numeric enum — `tsc` flags that comparison as having no overlap once the type is honest, which is what surfaced this.
- Fail loudly at head when a run scanned more than 1,000,000 blocks and found **zero** collections, naming the addresses it filtered on and saying the file on disk must be discarded. Reaching head proves the run finished, not that it worked. The threshold sits well above a weekly refresh (~300k blocks) so a routine run cannot trip it.

## Test plan

- [x] `npm run build`
- [x] Resumed from 89442800 against the real Portal and confirmed the previously-missed collection is captured
- [ ] Full mainnet regeneration — run after merge, since it resumes from the committed snapshot