### PR TITLE
fix: require the portal's own api key

### DIFF
--- a/src/common/utils/portal.ts
+++ b/src/common/utils/portal.ts
@@ -20,23 +20,28 @@ export function portalSource(dataset: string): {
   http: { headers: Record<string, string> };
 } {
   const host = process.env.SQD_PORTAL_URL || DEFAULT_PORTAL_HOST;
-  // Today the key arrives as SQUID_API_KEY: that is the variable already wired to every squid
-  // service (SSM `ops-param-subsquid-api-key`), and that parameter now holds the Portal key.
+  // SQD_PORTAL_API_KEY is the Portal's OWN key (SSM `ops-param-sqd-portal-api-key`) and is the
+  // variable to use. The two fallbacks are transitional, read in order of decreasing safety:
   //
-  // TRANSITIONAL. The same variable is what the pre-Portal trades squid still passes to the v2
-  // archive as `setGateway({ apiKey })`, and those are two different SQD products with two
-  // different keys — one parameter cannot serve both. It works today only because a processor at
-  // the head reads from the RPC and only falls back to the archive when it drops far behind. Once
-  // trades is promoted onto its Portal build it stops needing the archive key entirely; give the
-  // Portal its own parameter then and drop the fallback below.
-  const apiKey = process.env.SQD_API_KEY || process.env.SQUID_API_KEY;
+  //  - SQD_API_KEY is the name this helper originally shipped with; it is not mapped in definitions.
+  //  - SQUID_API_KEY is the v2 ARCHIVE key. It served the Portal only because that one parameter was
+  //    temporarily loaded with the Portal key. Now that the Portal has its own parameter,
+  //    `ops-param-subsquid-api-key` is free to go back to holding the archive key — and then this
+  //    fallback would send the WRONG key to the Portal. Preferring the dedicated variable is what
+  //    keeps that from silently breaking ingestion on the next deploy.
+  //
+  // Both fallbacks can be dropped once every squid service maps SQD_PORTAL_API_KEY.
+  const apiKey =
+    process.env.SQD_PORTAL_API_KEY ||
+    process.env.SQD_API_KEY ||
+    process.env.SQUID_API_KEY;
   return {
     url: `${host}/datasets/${dataset}`,
     http: {
       headers: {
         "x-api-key": assertNotNull(
           apiKey,
-          "Neither SQD_API_KEY nor SQUID_API_KEY is set — the shared Portal endpoint is authenticated"
+          "SQD_PORTAL_API_KEY is not set — the shared Portal endpoint is authenticated"
         ),
       },
     },


### PR DESCRIPTION
`portalSource` read `SQD_API_KEY || SQUID_API_KEY` and never `SQD_PORTAL_API_KEY`, the variable decentraland/definitions#1661 (merged) introduces for the Portal's own key — already mapped on both marketplace squid servers.

## This is no longer hypothetical

`SQUID_API_KEY` is the **v2 archive** key (SSM `ops-param-subsquid-api-key`). It worked for the Portal only while that one parameter was temporarily loaded with a Portal key. It is now demonstrably *not* a valid Portal key: the trades squid, whose services still map only that variable, sent it to `shared.portal.sqd.dev` on its first deploy and got `403` on every batch, crash-looping both processors.

The marketplace processors running today are unaffected — ECS resolves SSM at task start, so they keep the value they booted with. **The next deploy of this squid is what breaks**, and it would break the same way: a 403 with no obvious connection to the parameter change that caused it.

## Change

Read `SQD_PORTAL_API_KEY` and nothing else.

The previous fallbacks are removed rather than reordered. This squid cannot fall back to the public Portal — its Polygon log filter is over the 256 KiB cap — so the only safe behaviour for a missing key is to fail loudly at startup with a message that names the variable, instead of authenticating with another product's key and failing later as a 403.

## Verified

Built and exercised: `SQD_PORTAL_API_KEY` set → `shared.portal.sqd.dev` with the header; only `SQUID_API_KEY` set → fails immediately with `SQD_PORTAL_API_KEY is not set`, which is what we want instead of a 403 mid-ingestion.

## Related

- decentraland/definitions#1661 — introduced the parameter (merged)
- decentraland/definitions#1662 — maps it on the trades servers, still open, which is why trades hit the 403
- decentraland/trades-squid-core#45, decentraland/credits-squid-core#33 — same correction in those helpers