### PR TITLE
chore: drop the parameter name from the portal comment

### DIFF
--- a/src/common/utils/portal.ts
+++ b/src/common/utils/portal.ts
@@ -20,8 +20,7 @@ export function portalSource(dataset: string): {
   http: { headers: Record<string, string> };
 } {
   const host = process.env.SQD_PORTAL_URL || DEFAULT_PORTAL_HOST;
-  // The Portal now has its own parameter (SSM `ops-param-sqd-portal-api-key`), and reading ONLY
-  // that one is the point of this function.
+  // The Portal now has its own key variable, and reading ONLY that one is the point of this function.
   //
   // It used to fall back to SQUID_API_KEY, which is the variable wired to every squid for the v2
   // archive (`setGateway({ apiKey })`, still how the trades squid ingests). Those are two products


### PR DESCRIPTION
This is a public repo, and the comment in `portalSource` names the internal SSM parameter that holds the Portal key. The comment reads the same without it — what matters is which env var is read, not where the value comes from.

Comment only; no behaviour change.

The same leak in `trades-squid-core` is removed by decentraland/trades-squid-core#45, which rewrites that comment anyway.