### PR TITLE
fix: bump typeorm-store so the hot path accepts a log-filtered stream

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@subsquid/portal-client": "^0.7.0",
         "@subsquid/rpc-client": "^4.15.0",
         "@subsquid/typeorm-migration": "^1.3.0",
-        "@subsquid/typeorm-store": "^1.5.1",
+        "@subsquid/typeorm-store": "^1.9.2",
         "dotenv": "^16.4.5",
         "ethers": "^6.11.1",
         "graphile-build": "^4.13.0",
@@ -2564,11 +2564,12 @@
       }
     },
     "node_modules/@subsquid/typeorm-config": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-config/-/typeorm-config-4.1.1.tgz",
-      "integrity": "sha512-3T2L2jmFIRYxWHL/w4rMuaSiHLhDywQWPKtfD3TaSohjXR+VdDG5XimDMmSwM4dzQTBToGpnfUEkzH3v1+EnCg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-config/-/typeorm-config-4.2.0.tgz",
+      "integrity": "sha512-eIkIPG/+mftvH521C+wSuAiyp/cED+wg9aACSPNTz30qTchi7ieHqSHpmw4OXkw376z0ujSK2OpFmWAuGTZOJA==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/logger": "^1.3.3",
+        "@subsquid/logger": "^1.6.0",
         "@subsquid/util-internal-ts-node": "^0.0.0",
         "@subsquid/util-naming": "^1.3.0"
       },
@@ -2579,6 +2580,17 @@
         "typeorm": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@subsquid/typeorm-config/node_modules/@subsquid/logger": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+      "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@subsquid/util-internal-hex": "^1.2.3",
+        "@subsquid/util-internal-json": "^1.2.3",
+        "supports-color": "^8.1.1"
       }
     },
     "node_modules/@subsquid/typeorm-migration": {
@@ -2605,12 +2617,13 @@
       }
     },
     "node_modules/@subsquid/typeorm-store": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-store/-/typeorm-store-1.5.1.tgz",
-      "integrity": "sha512-XIhc/4qotnJP+8RDxWjUdsSCr+LOPOAp9U+u0VCqnyXx5rN13MDS0L5KSkIGinr/OQtK1CBWmRpDLF4ExWcWCw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-store/-/typeorm-store-1.9.2.tgz",
+      "integrity": "sha512-LWMoJ9eSngcXCILwFBOUj2kTIaptCbJHLdRlv4lYmIKtg/EBwCAHCAF0e+3BvXZjWHLEznKB93fscL1PhtC40Q==",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@subsquid/typeorm-config": "^4.1.1",
-        "@subsquid/util-internal": "^3.2.0"
+        "@subsquid/typeorm-config": "^4.2.0",
+        "@subsquid/util-internal": "^3.3.1"
       },
       "peerDependencies": {
         "@subsquid/big-decimal": "^1.0.0",
@@ -9687,13 +9700,25 @@
       }
     },
     "@subsquid/typeorm-config": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-config/-/typeorm-config-4.1.1.tgz",
-      "integrity": "sha512-3T2L2jmFIRYxWHL/w4rMuaSiHLhDywQWPKtfD3TaSohjXR+VdDG5XimDMmSwM4dzQTBToGpnfUEkzH3v1+EnCg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-config/-/typeorm-config-4.2.0.tgz",
+      "integrity": "sha512-eIkIPG/+mftvH521C+wSuAiyp/cED+wg9aACSPNTz30qTchi7ieHqSHpmw4OXkw376z0ujSK2OpFmWAuGTZOJA==",
       "requires": {
-        "@subsquid/logger": "^1.3.3",
+        "@subsquid/logger": "^1.6.0",
         "@subsquid/util-internal-ts-node": "^0.0.0",
         "@subsquid/util-naming": "^1.3.0"
+      },
+      "dependencies": {
+        "@subsquid/logger": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@subsquid/logger/-/logger-1.6.0.tgz",
+          "integrity": "sha512-k33Cw1uO+Boha08arS8nhr0VHfT+bTWGe/hTZDeCDMoa2i0SUgkiDGDkgqTQof6y/N/kl30KzPvAAGqwJ6MJNw==",
+          "requires": {
+            "@subsquid/util-internal-hex": "^1.2.3",
+            "@subsquid/util-internal-json": "^1.2.3",
+            "supports-color": "^8.1.1"
+          }
+        }
       }
     },
     "@subsquid/typeorm-migration": {
@@ -9710,12 +9735,12 @@
       }
     },
     "@subsquid/typeorm-store": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-store/-/typeorm-store-1.5.1.tgz",
-      "integrity": "sha512-XIhc/4qotnJP+8RDxWjUdsSCr+LOPOAp9U+u0VCqnyXx5rN13MDS0L5KSkIGinr/OQtK1CBWmRpDLF4ExWcWCw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@subsquid/typeorm-store/-/typeorm-store-1.9.2.tgz",
+      "integrity": "sha512-LWMoJ9eSngcXCILwFBOUj2kTIaptCbJHLdRlv4lYmIKtg/EBwCAHCAF0e+3BvXZjWHLEznKB93fscL1PhtC40Q==",
       "requires": {
-        "@subsquid/typeorm-config": "^4.1.1",
-        "@subsquid/util-internal": "^3.2.0"
+        "@subsquid/typeorm-config": "^4.2.0",
+        "@subsquid/util-internal": "^3.3.1"
       }
     },
     "@subsquid/util-internal": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@subsquid/graphql-server": "^4.9.0",
     "@subsquid/openreader": "^5.2.0",
     "@subsquid/typeorm-migration": "^1.3.0",
-    "@subsquid/typeorm-store": "^1.5.1",
+    "@subsquid/typeorm-store": "^1.9.2",
     "dotenv": "^16.4.5",
     "ethers": "^6.11.1",
     "graphile-build": "^4.13.0",


### PR DESCRIPTION
Follow-up to #116. That PR turned on `supportHotBlocks: true` for the eth processor to stop L1 cancellations from taking ~15 minutes to appear. Deployed to the idle slot, the eth processor crash-looped on startup:

```
[eth-processor] FATAL AssertionError: blocks must form a continues chain
Process [eth-processor] failed with exit code: 1
```

## Why #116 was not enough

The blocking assertion lives in `@subsquid/typeorm-store`, which #116 did not bump:

```js
// 1.5.1, the version running
assert(b.height === prev.height + 1, 'blocks must form a continues chain')
```

That demands strict adjacency. A log-filtered stream only returns the blocks that matched a filter, so consecutive blocks are never adjacent and the hot path rejects every batch.

1.9.2 relaxes it to what a filtered stream can actually satisfy:

```js
assert(b.height > prev.height, 'blocks must form a continues chain')
```

The comment #116 replaced was therefore correct about the constraint, and wrong only about where it lived. I checked `batch-processor` and `evm-stream`, found their continuity checks were monotonic, and concluded the constraint did not exist without checking the one package that implements `transactHot2`.

## Hot-path assertions, all four packages this time

| package | assertion | verdict |
|---|---|---|
| typeorm-store 1.9.2 | `blocks must form a continues chain` | relaxed to monotonic, satisfied |
| batch-processor 1.1.0 | `Data is not continuous` | monotonic, satisfied |
| batch-processor 1.1.0 | `non-hot database received unfinalized blocks` | non-hot branch only, unreachable with hot on |
| batch-processor 1.1.0 | `Unable to process fork` | see below |
| evm-stream 0.1.4 | `portal has no chain head` | only when the Portal serves no head |
| portal-client 0.7.0 | none | |

`Unable to process fork` throws when a reorg runs deeper than the recovery log, meaning below our oldest finalized block. On Ethereum that is a reorg past two epochs, a consensus-level event rather than routine churn. It is a real bound, and it is not the one that concerns this change.

## Compatibility

`TypeormDatabaseOptions` gains one optional field (`templates?`) between 1.5.1 and 1.9.2. Nothing is removed, the public methods are identical, and `transactHot2` keeps its shape. The lockfile is updated because the snapshot-refresh workflow runs `npm ci`.

## Test plan

- [ ] Deploy to the idle slot and confirm the eth processor no longer crash-loops
- [ ] Confirm eth reaches head and stays there
- [ ] Confirm `sqd_processor_chain_height` tracks the real tip rather than the finalized head
- [ ] Cancel a cheap L1 listing and measure transaction confirmation to the API dropping it
- [ ] Diff the 23 shared tables against the promoted schema before promoting