### PR TITLE
fix: stop pinning search_path to a schema that promotion renames

### DIFF
--- a/indexer.sh
+++ b/indexer.sh
@@ -98,10 +98,22 @@ unset PGPASSWORD
 
 # Construct the DB_URL with the new user
 export DB_URL=postgresql://$NEW_DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
-export DB_SCHEMA=$NEW_SCHEMA_NAME
+# The deployment's schema name goes to SQUID_SCHEMA, and DB_SCHEMA is left unset.
+#
+# @subsquid/typeorm-config >= 4.2.0 turns DB_SCHEMA into a per-connection
+# `options=-c search_path="<name>"` sent in the pg startup packet, which overrides the
+# role's default search_path on every connection. That is incompatible with promotion:
+# the management server RENAMES this schema to squid_marketplace and updates the role's
+# default, so a pinned name goes stale the instant the squid is promoted. Every
+# unqualified query then fails with "relation does not exist", and because the pin comes
+# from the environment rather than from a stale session, restarting the process cannot
+# recover it. Leaving DB_SCHEMA unset keeps the role default authoritative, which is
+# exactly what the ALTER USER above and the promote both maintain.
+export SQUID_SCHEMA=$NEW_SCHEMA_NAME
+unset DB_SCHEMA
 
 # Log the constructed DB_URL
-echo "Exported DB_SCHEMA: $DB_SCHEMA"
+echo "Exported SQUID_SCHEMA: $SQUID_SCHEMA"
 
 # Start the processor service and the GraphQL server, and write logs to a file
 LOG_FILE="sqd_run_log_${CURRENT_TIMESTAMP}.txt"

--- a/restart.sh
+++ b/restart.sh
@@ -18,11 +18,13 @@ fi
 
 # Construct the DB_URL with the new user
 export DB_URL=postgresql://$SQUID_DB_USER:$DB_PASSWORD@$DB_HOST:$DB_PORT/$DB_NAME
-export DB_SCHEMA=$SQUID_SCHEMA
+# Exported as SQUID_SCHEMA, never DB_SCHEMA: see the note in indexer.sh.
+export SQUID_SCHEMA
+unset DB_SCHEMA
 
 # Log the constructed DB_URL
 echo "Exported DB_URL: $DB_URL"
-echo "Exported DB_SCHEMA: $DB_SCHEMA"
+echo "Exported SQUID_SCHEMA: $SQUID_SCHEMA"
 
 export CURRENT_SQUID_DB_USER=$SQUID_DB_USER
 echo "Exported CURRENT_SQUID_DB_USER: $SQUID_DB_USER"

--- a/src/common/utils/head-notification.ts
+++ b/src/common/utils/head-notification.ts
@@ -9,11 +9,12 @@ const ENV_LABEL = isMainnet ? "prd" : "dev";
 
 // The status table must be referenced UNQUALIFIED. The management server's promote
 // physically RENAMES the indexer schema (marketplace_squid_<ts> -> squid_marketplace)
-// and updates the writer role's search_path, so a name qualified with DB_SCHEMA goes
-// stale after promotion ("schema does not exist" on every batch). An unqualified name
-// follows the rename through search_path, exactly like every entity table does.
-// DB_SCHEMA remains the deployment's identity and is used for Slack labels only.
-const SCHEMA = process.env.DB_SCHEMA;
+// and updates the writer role's search_path, so a name qualified with the deployment's
+// own schema goes stale after promotion ("schema does not exist" on every batch). An
+// unqualified name follows the rename through search_path, like every entity table does.
+// SQUID_SCHEMA carries the deployment's identity and is used for Slack labels only.
+// DB_SCHEMA is deliberately unset, because typeorm-config would pin search_path to it.
+const SCHEMA = process.env.SQUID_SCHEMA;
 const STATUS_TABLE = "head_sync_status";
 
 let slackComponent: ISlackComponent | undefined;

--- a/src/eth/main.ts
+++ b/src/eth/main.ts
@@ -100,7 +100,9 @@ let indexRecreateAttempts = 0;
 const MAX_INDEX_RECREATE_ATTEMPTS = 5;
 const ETH_INITIAL_BLOCK = getBlockRange(Network.ETHEREUM).from;
 
-const schemaName = process.env.DB_SCHEMA;
+// SQUID_SCHEMA, not DB_SCHEMA: typeorm-config would turn the latter into a
+// per-connection search_path pin that promotion invalidates (see indexer.sh).
+const schemaName = process.env.SQUID_SCHEMA;
 const db = new TypeormDatabase({
   isolationLevel: "READ COMMITTED",
   // Index the unfinalized tip, and roll it back if the chain reorganises.

--- a/src/polygon/main.ts
+++ b/src/polygon/main.ts
@@ -117,7 +117,9 @@ import {
   notifyHeadReachedOnce,
 } from "../common/utils/head-notification";
 
-const schemaName = process.env.DB_SCHEMA;
+// SQUID_SCHEMA, not DB_SCHEMA: typeorm-config would turn the latter into a
+// per-connection search_path pin that promotion invalidates (see indexer.sh).
+const schemaName = process.env.SQUID_SCHEMA;
 const addresses = getAddresses(Network.MATIC);
 let bytesRead = 0; // amount of bytes received
 


### PR DESCRIPTION
## The bug

Promoting slot A crash-looped and never recovered, while slot B promoted cleanly. The two slots run different builds, and the difference is a transitive dependency.

`@subsquid/typeorm-config` 4.2.0 (pulled in by the `@subsquid/typeorm-store` `^1.5.1` -> `^1.9.2` bump) added this to `createConnectionOptions()`:

```js
let searchPathOptions = getDataSchemaSearchPath()   // `-c search_path="$DB_SCHEMA"`
if (searchPathOptions) {
    con.extra = { options: searchPathOptions }      // passed straight to the pg pool
}
```

TypeORM forwards `extra` to `pg`, which sends it in the connection startup packet. A `search_path` in the startup packet **overrides the role's default on every connection**.

That is incompatible with how promotion works here. The management server RENAMES the deployment's schema to `squid_marketplace` and updates the writer role's default `search_path`. `DB_SCHEMA` is fixed in the container environment at task start and nobody updates it, so from the moment a squid is promoted every connection pins `search_path` to a schema that no longer exists:

- `current_schema()` returns NULL (`search_path` has no `,public` fallback by default)
- every unqualified query fails: `relation "rarity" does not exist`, `relation "account" does not exist`
- migrations fail at boot with `no schema has been selected to create in`
- **restarting cannot recover it**, because the pin comes from the environment rather than from a stale session

Slot B was unaffected only because it resolves `typeorm-config` 4.1.1, which has none of this and lets the role default rule.

## Changes

- `indexer.sh` and `restart.sh` export the deployment's schema name as `SQUID_SCHEMA` and explicitly `unset DB_SCHEMA`, so the role's default `search_path` stays authoritative. That default is already maintained in both places that matter: `ALTER USER ... SET search_path` at deploy time, and the promote.
- The three readers (`src/eth/main.ts`, `src/polygon/main.ts`, `src/common/utils/head-notification.ts`) read `SQUID_SCHEMA`. They use it for the processor `stateSchema` and for Slack labels, never for `search_path`.

The `stateSchema` values (`eth_processor_<name>`, `polygon_processor_<name>`) are unaffected: promotion does not rename those schemas, so they stay valid.

## Test plan

- [ ] Deploy to the idle slot and confirm the startup log prints `Exported SQUID_SCHEMA:` and that the reindex writes into the new schema
- [ ] Confirm the GraphQL API and the processors resolve entity tables with `DB_SCHEMA` unset
- [ ] Promote the slot and confirm the processors keep advancing, recovering within seconds if in-flight sessions are interrupted